### PR TITLE
Create config class

### DIFF
--- a/pynecone/.templates/app/tutorial.py
+++ b/pynecone/.templates/app/tutorial.py
@@ -1,10 +1,10 @@
 """Welcome to Pynecone! This file outlines the steps to create a basic app."""
-import pcconfig
+from pcconfig import config
 
 import pynecone as pc
 
 docs_url = "https://pynecone.io/docs/getting-started/introduction"
-filename = f"{pcconfig.APP_NAME}/{pcconfig.APP_NAME}.py"
+filename = f"{config.app_name}/{config.app_name}.py"
 
 
 class State(pc.State):
@@ -16,17 +16,22 @@ class State(pc.State):
 def index():
     return pc.center(
         pc.vstack(
-            pc.heading("Welcome to Pynecone!"),
-            pc.box("Get started by editing ", pc.code(filename)),
+            pc.heading("Welcome to Pynecone!", font_size="2em"),
+            pc.box("Get started by editing ", pc.code(filename, font_size="1em")),
             pc.link(
                 "Check out our docs!",
                 href=docs_url,
                 border="0.1em solid",
                 padding="0.5em",
                 border_radius="0.5em",
+                _hover={
+                    "color": "rgb(107,99,246)",
+                },
             ),
+            spacing="1.5em",
+            font_size="2em",
         ),
-        padding="5em",
+        padding_top="10%",
     )
 
 

--- a/pynecone/__init__.py
+++ b/pynecone/__init__.py
@@ -6,6 +6,8 @@ Anything imported here will be available in the default Pynecone import as `pc.*
 from .app import App
 from .base import Base
 from .components import *
+from .config import Config
+from .constants import Env
 from .event import console_log, redirect, window_alert
 from .model import Model, session
 from .state import ComputedVar as var

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -215,15 +215,15 @@ class App(Base):
     def compile(self, ignore_env: bool = False):
         """Compile the app and output it to the pages folder.
 
-        If the pcconfig environment is set to production, the app will
+        If the config environment is set to production, the app will
         not be compiled.
 
         Args:
-            ignore_env: Whether to ignore the pcconfig environment.
+            ignore_env: Whether to ignore the config environment.
         """
         # Get the env mode.
         config = utils.get_config()
-        if not ignore_env and config.ENV != constants.Env.DEV.value:
+        if not ignore_env and config.env != constants.Env.DEV:
             print("Skipping compilation in non-dev mode.")
             return
 

--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -6,13 +6,12 @@ from pynecone import constants
 from pynecone.utils import join
 
 # Template for the Pynecone config file.
-PCCONFIG = f"""# The Pynecone configuration file.
+PCCONFIG = f"""import pynecone as pc
 
-APP_NAME = "{{app_name}}"
-API_HOST = "http://localhost:8000"
-BUN_PATH = "$HOME/.bun/bin/bun"
-ENV = "{constants.Env.DEV.value}"
-DB_URI = "sqlite:///{constants.DB_NAME}"
+
+config = pc.Config(
+    app_name="{{app_name}}",
+)
 """
 
 # Javascript formatting.

--- a/pynecone/config.py
+++ b/pynecone/config.py
@@ -19,6 +19,9 @@ class Config(Base):
     # The redis url.
     redis_url: Optional[str] = None
 
+    # The deploy url.
+    deploy_url: Optional[str] = None
+
     # The environment mode.
     env: constants.Env = constants.Env.DEV
 

--- a/pynecone/config.py
+++ b/pynecone/config.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from pynecone import constants
+from pynecone.base import Base
+
+
+class Config(Base):
+    """A Pynecone config."""
+
+    # The name of the app.
+    app_name: str
+
+    # The backend API url.
+    api_url: str = "http://localhost:8000"
+
+    # The database url.
+    db_url: str = f"sqlite:///{constants.DB_NAME}"
+
+    # The redis url.
+    redis_url: Optional[str] = None
+
+    # The environment mode.
+    env: constants.Env = constants.Env.DEV
+
+    # The path to the bun executable.
+    bun_path: str = "$HOME/.bun/bin/bun"

--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -134,5 +134,7 @@ class Endpoint(Enum):
         Returns:
             The full URL for the endpoint.
         """
-        pcconfig = __import__(CONFIG_MODULE)
-        return "".join([pcconfig.API_HOST, str(self)])
+        from pynecone import utils
+
+        config = utils.get_config()
+        return "".join([config.api_url, str(self)])

--- a/pynecone/model.py
+++ b/pynecone/model.py
@@ -12,8 +12,8 @@ def get_engine():
     Returns:
         The database engine.
     """
-    uri = utils.get_config().DB_URI
-    return sqlmodel.create_engine(uri, echo=False)
+    url = utils.get_config().db_url
+    return sqlmodel.create_engine(url, echo=False)
 
 
 class Model(Base, sqlmodel.SQLModel):

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -87,11 +87,11 @@ def deploy(dry_run: bool = False):
         dry_run: Whether to run a dry run.
     """
     # Get the app config.
-    pcconfig = utils.get_config()
-    pcconfig.API_HOST = utils.get_production_backend_url()
+    config = utils.get_config()
+    config.api_url = utils.get_production_backend_url()
 
-    # Check if the deploy URI is set.
-    if not hasattr(pcconfig, "DEPLOY_URI"):
+    # Check if the deploy url is set.
+    if config.deploy_url is None:
         typer.echo("This feature is coming soon!")
         typer.echo("Join our waitlist to be notified: https://pynecone.io/waitlist")
         return
@@ -106,8 +106,8 @@ def deploy(dry_run: bool = False):
         return
 
     # Deploy the app.
-    data = {"userId": pcconfig.USERNAME, "projectId": pcconfig.APP_NAME}
-    original_response = requests.get(pcconfig.DEPLOY_URI, params=data)
+    data = {"userId": config.username, "projectId": config.app_name}
+    original_response = requests.get(config.deploy_url, params=data)
     response = original_response.json()
     print("response", response)
     frontend = response["frontend_resources_url"]


### PR DESCRIPTION
Created a new class: `pc.Config`

Now the new default `pcconfig.py` file looks something like:
```
import pynecone as pc


config = pc.Config(
    app_name="asdf",
)
```

and extra fields can just be passed as keyword arguments inside there.
This way they don't have to see the defaults also.