### PR TITLE
Improve prop error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img width="600" src="docs/images/logo_white.svg#gh-dark-mode-only" alt="Pynecone Logo">
 </h1>
 
-**Build performant, customizable web apps in minutes just using Python.**
+**Build performant, customizable web apps in pure Python.**
 
 [![PyPI version](https://badge.fury.io/py/pynecone-io.svg)](https://badge.fury.io/py/pynecone-io)
 ![tests](https://github.com/pynecone-io/pynecone/actions/workflows/build.yml/badge.svg)

--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -71,6 +71,9 @@ class Component(Base, ABC):
         Args:
             *args: Args to initialize the component.
             **kwargs: Kwargs to initialize the component.
+
+        Raises:
+            TypeError: If an invalid prop is passed.
         """
         # Get the component fields, triggers, and props.
         fields = self.get_fields()

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -22,6 +22,14 @@ def version():
 def init():
     """Initialize a new Pynecone app."""
     app_name = utils.get_default_app_name()
+
+    # Make sure they don't name the app "pynecone".
+    if app_name == constants.MODULE_NAME:
+        utils.console.print(
+            f"[red]The app directory cannot be named {constants.MODULE_NAME}."
+        )
+        raise typer.Exit()
+
     with utils.console.status(f"[bold]Initializing {app_name}") as status:
         # Only create the app directory if it doesn't exist.
         if not os.path.exists(constants.CONFIG_FILE):
@@ -64,6 +72,15 @@ def run(
         frontend: Whether to run the frontend.
         backend: Whether to run the backend.
     """
+    # Check that the app is initialized.
+    if not os.path.exists(constants.CONFIG_FILE) or not os.path.exists(
+        constants.WEB_DIR
+    ):
+        utils.console.print(
+            f"[red]The app is not initialized. Run [bold]pc init[/bold] first."
+        )
+        raise typer.Exit()
+
     utils.console.rule("[bold]Starting Pynecone App")
     app = utils.get_app()
 

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -20,17 +20,21 @@ def version():
 
 @cli.command()
 def init():
-    """Initialize a new Pynecone app."""
+    """Initialize a new Pynecone app.
+
+    Raises:
+        Exit: If the app directory is invalid.
+    """
     app_name = utils.get_default_app_name()
 
     # Make sure they don't name the app "pynecone".
     if app_name == constants.MODULE_NAME:
         utils.console.print(
-            f"[red]The app directory cannot be named {constants.MODULE_NAME}."
+            f"[red]The app directory cannot be named [bold]{constants.MODULE_NAME}."
         )
         raise typer.Exit()
 
-    with utils.console.status(f"[bold]Initializing {app_name}") as status:
+    with utils.console.status(f"[bold]Initializing {app_name}"):
         # Only create the app directory if it doesn't exist.
         if not os.path.exists(constants.CONFIG_FILE):
             # Create a configuration file.
@@ -71,11 +75,12 @@ def run(
         env: The environment to run the app in.
         frontend: Whether to run the frontend.
         backend: Whether to run the backend.
+
+    Raises:
+        Exit: If the app is not initialized.
     """
     # Check that the app is initialized.
-    if not os.path.exists(constants.CONFIG_FILE) or not os.path.exists(
-        constants.WEB_DIR
-    ):
+    if not utils.is_initialized():
         utils.console.print(
             f"[red]The app is not initialized. Run [bold]pc init[/bold] first."
         )

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -320,6 +320,15 @@ def install_dependencies():
     subprocess.call([get_bun_path(), "install"], cwd=constants.WEB_DIR, stdout=PIPE)
 
 
+def is_initialized() -> bool:
+    """Check whether the app is initialized.
+
+    Returns:
+        Whether the app is initialized in the current directory.
+    """
+    return os.path.exists(constants.CONFIG_FILE) and os.path.exists(constants.WEB_DIR)
+
+
 def export_app(app):
     """Zip up the app for deployment.
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -57,7 +57,11 @@ def component2() -> Type[Component]:
 
         @classmethod
         def get_controlled_triggers(cls) -> Set[str]:
-            """Test controlled triggers."""
+            """Test controlled triggers.
+
+            Returns:
+                Test controlled triggers.
+            """
             return {"on_open", "on_close"}
 
         def _get_imports(self) -> ImportDict:
@@ -97,7 +101,7 @@ def on_click2() -> EventHandler:
     return EventHandler(fn=on_click2)
 
 
-def test_set_style_attrs(component1: Type[Component]):
+def test_set_style_attrs(component1):
     """Test that style attributes are set in the dict.
 
     Args:
@@ -108,7 +112,7 @@ def test_set_style_attrs(component1: Type[Component]):
     assert component.style["textAlign"] == "center"
 
 
-def test_create_component(component1: Type[Component]):
+def test_create_component(component1):
     """Test that the component is created correctly.
 
     Args:
@@ -122,7 +126,7 @@ def test_create_component(component1: Type[Component]):
     assert c.style == {"color": "white", "textAlign": "center"}
 
 
-def test_add_style(component1: Type[Component], component2: Type[Component]):
+def test_add_style(component1, component2):
     """Test adding a style to a component.
 
     Args:
@@ -139,7 +143,7 @@ def test_add_style(component1: Type[Component], component2: Type[Component]):
     assert c2.style["color"] == "black"
 
 
-def test_get_imports(component1: Type[Component], component2: Type[Component]):
+def test_get_imports(component1, component2):
     """Test getting the imports of a component.
 
     Args:
@@ -152,7 +156,7 @@ def test_get_imports(component1: Type[Component], component2: Type[Component]):
     assert c2.get_imports() == {"react-redux": {"connect"}, "react": {"Component"}}
 
 
-def test_get_custom_code(component1: Type[Component], component2: Type[Component]):
+def test_get_custom_code(component1, component2):
     """Test getting the custom code of a component.
 
     Args:
@@ -180,7 +184,7 @@ def test_get_custom_code(component1: Type[Component], component2: Type[Component
     }
 
 
-def test_get_props(component1: Type[Component], component2: Type[Component]):
+def test_get_props(component1, component2):
     """Test that the props are set correctly.
 
     Args:
@@ -199,8 +203,8 @@ def test_get_props(component1: Type[Component], component2: Type[Component]):
         ("hi", -13),
     ],
 )
-def test_valid_props(component1: Type[Component], text: str, number: int):
-    """ "Test that we can construct a component with valid props.
+def test_valid_props(component1, text: str, number: int):
+    """Test that we can construct a component with valid props.
 
     Args:
         component1: A test component.
@@ -215,7 +219,7 @@ def test_valid_props(component1: Type[Component], text: str, number: int):
 @pytest.mark.parametrize(
     "text,number", [("", "bad_string"), (13, 1), (None, 1), ("test", [1, 2, 3])]
 )
-def test_invalid_prop_type(component1: Type[Component], text: str, number: int):
+def test_invalid_prop_type(component1, text: str, number: int):
     """Test that an invalid prop type raises an error.
 
     Args:
@@ -228,15 +232,18 @@ def test_invalid_prop_type(component1: Type[Component], text: str, number: int):
         component1.create(text=text, number=number)
 
 
-def test_var_props(component1: Type[Component], TestState: Type[State]):
-    """Test that we can set a Var prop."""
+def test_var_props(component1, TestState):
+    """Test that we can set a Var prop.
+
+    Args:
+        component1: A test component.
+        TestState: A test state.
+    """
     c1 = component1.create(text="hello", number=TestState.num)
     assert c1.number == TestState.num
 
 
-def test_get_controlled_triggers(
-    component1: Type[Component], component2: Type[Component]
-):
+def test_get_controlled_triggers(component1, component2):
     """Test that we can get the controlled triggers of a component.
 
     Args:
@@ -247,7 +254,7 @@ def test_get_controlled_triggers(
     assert component2.get_controlled_triggers() == {"on_open", "on_close"}
 
 
-def test_get_triggers(component1: Type[Component], component2: Type[Component]):
+def test_get_triggers(component1, component2):
     """Test that we can get the triggers of a component.
 
     Args:


### PR DESCRIPTION
Fix a range of errors we found over the launch:
* make sure the app is not named "pynecone"
* check that the user ran `pc init` before `pc run`
* add better error messages when setting invalid prop types
* add some unit tests for components