### PR TITLE
Improve event processing performance

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -604,14 +604,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyright"
-version = "1.1.284"
+version = "1.1.285"
 description = "Command line wrapper for pyright"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.284-py3-none-any.whl", hash = "sha256:e3bfbd33c20af48eed9d20138767265161ba8a4b55c740476a36ce822bd482d1"},
-    {file = "pyright-1.1.284.tar.gz", hash = "sha256:ef7c0e46e38be95687f5a0633e55c5171ca166048b9560558168a976162e287c"},
+    {file = "pyright-1.1.285-py3-none-any.whl", hash = "sha256:8a6b60b3ff0d000c549621c367cdf0013abdaf24d09e6f0b4b95031b357cc4b1"},
+    {file = "pyright-1.1.285.tar.gz", hash = "sha256:ecd28e8556352e2c7eb5f412c6841ec768d25e8a6136326d4a6a67d94370eba1"},
 ]
 
 [package.dependencies]

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -124,10 +124,15 @@ export const updateState = async (state, result, setResult, router, socket) => {
  * @param endpoint The endpoint to connect to.
  */
 export const connect = async (socket, state, result, setResult, router, endpoint) => {
+  // Create the socket.
   socket.current = new WebSocket(endpoint);
+
+  // Once the socket is open, hydrate the page.
   socket.current.onopen = () => {
     updateState(state, result, setResult, router, socket.current)
   }
+
+  // On each received message, apply the delta and set the result.
   socket.current.onmessage = function (update) {
     update = JSON.parse(update.data);
     applyDelta(state, update.delta);

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -123,8 +123,11 @@ export const updateState = async (state, result, setResult, router, socket) => {
  * @param setResult The function to set the result.
  * @param endpoint The endpoint to connect to.
  */
-export const connect = async (socket, state, setResult, endpoint) => {
+export const connect = async (socket, state, result, setResult, router, endpoint) => {
   socket.current = new WebSocket(endpoint);
+  socket.current.onopen = () => {
+    updateState(state, result, setResult, router, socket.current)
+  }
   socket.current.onmessage = function (update) {
     update = JSON.parse(update.data);
     applyDelta(state, update.delta);

--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -144,7 +144,7 @@ USE_EFFECT = join(
     [
         "useEffect(() => {{",
         f"  if (!{SOCKET}.current) {{{{",
-        f"    connect({SOCKET}, {{state}}, {SET_RESULT}, {EVENT_ENDPOINT})",
+        f"    connect({SOCKET}, {{state}}, {RESULT}, {SET_RESULT}, {ROUTER}, {EVENT_ENDPOINT})",
         "  }}",
         "  const update = async () => {{",
         f"    if ({RESULT}.{STATE} != null) {{{{",

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -257,6 +257,9 @@ class State(Base, ABC):
             field.required = False
             field.default = default_value
 
+    def getattr(self, name: str) -> Any:
+        return super().__getattribute__(name)
+
     def __getattribute__(self, name: str) -> Any:
         """Get the attribute.
 
@@ -287,17 +290,19 @@ class State(Base, ABC):
             name: The name of the attribute.
             value: The value of the attribute.
         """
-        if name != "inherited_vars" and name in self.inherited_vars:
-            setattr(self.parent_state, name, value)
+        if name != "inherited_vars" and name in super().__getattribute__("inherited_vars"):
+            setattr(super().__getattribute__("parent_state"), name, value)
             return
 
         # Set the attribute.
         super().__setattr__(name, value)
 
         # Add the var to the dirty list.
-        if name in self.vars:
-            self.dirty_vars.add(name)
-            self.mark_dirty()
+        if name in super().__getattribute__("vars"):
+            super().__getattribute__("dirty_vars").add(name)
+            super().__getattribute__("mark_dirty")()
+            # self.dirty_vars.add(name)
+            # self.mark_dirty()
 
     def reset(self):
         """Reset all the base vars to their default values."""
@@ -411,12 +416,15 @@ class State(Base, ABC):
     def clean(self):
         """Reset the dirty vars."""
         # Recursively clean the substates.
-        for substate in self.dirty_substates:
-            self.substates[substate].clean()
+        for substate in super().__getattribute__("dirty_substates"):
+            super().__getattribute__("substates")[substate].getattr("clean")()
+        #     super().__getattribute__("substates")[substate].__getattribute__("clean")()
 
         # Clean this state.
-        self.dirty_vars = set()
-        self.dirty_substates = set()
+        super().__setattr__("dirty_vars", set())
+        super().__setattr__("dirty_substates", set())
+        # self.dirty_vars = set()
+        # self.dirty_substates = set()
 
     def dict(self, include_computed: bool = True, **kwargs) -> Dict[str, Any]:
         """Convert the object to a dictionary.

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -290,7 +290,9 @@ class State(Base, ABC):
             name: The name of the attribute.
             value: The value of the attribute.
         """
-        if name != "inherited_vars" and name in super().__getattribute__("inherited_vars"):
+        if name != "inherited_vars" and name in super().__getattribute__(
+            "inherited_vars"
+        ):
             setattr(super().__getattribute__("parent_state"), name, value)
             return
 
@@ -392,14 +394,16 @@ class State(Base, ABC):
         # Return the dirty vars, as well as all computed vars.
         subdelta = {
             prop: getattr(self, prop)
-            for prop in self.dirty_vars | set(self.computed_vars.keys())
+            for prop in super().__getattribute__("dirty_vars")
+            | set(super().__getattribute__("computed_vars").keys())
         }
         if len(subdelta) > 0:
-            delta[self.get_full_name()] = subdelta
+            delta[super().__getattribute__("get_full_name")()] = subdelta
 
         # Recursively find the substate deltas.
-        for substate in self.dirty_substates:
-            delta.update(self.substates[substate].get_delta())
+        substates = super().__getattribute__("substates")
+        for substate in super().__getattribute__("dirty_substates"):
+            delta.update(substates[substate].getattr("get_delta")())
 
         # Format the delta.
         delta = utils.format_state(delta)

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -876,6 +876,7 @@ def format_state(value: Any) -> Dict:
         f"Got var of type {type(value)}."
     )
 
+
 def get_event(state, event):
     """Get the event from the given state.
 


### PR DESCRIPTION
* Reorder if statements in format_state to handle most common vars first (this provided a big speedup)
* Use `super().__getattribute__` in functions in the critical path of event processing. It's ugly but it's faster.
* Add `onopen` for web socket to hydrate the page on initial load.