### PR TITLE
Add echarts-for-react Graphing Component

### DIFF
--- a/pynecone/.templates/web/package.json
+++ b/pynecone/.templates/web/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "axios": "^0.27.2",
+    "fast-deep-equal": "^3.1.3",
     "echarts": "^5.4.1",
     "echarts-for-react": "^3.0.2",
     "focus-visible": "^5.2.0",

--- a/pynecone/.templates/web/package.json
+++ b/pynecone/.templates/web/package.json
@@ -12,6 +12,8 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "axios": "^0.27.2",
+    "echarts": "^5.4.1",
+    "echarts-for-react": "^3.0.2",
     "focus-visible": "^5.2.0",
     "framer-motion": "^6.3.3",
     "gridjs": "^4.0.0",

--- a/pynecone/components/graphing/__init__.py
+++ b/pynecone/components/graphing/__init__.py
@@ -1,5 +1,6 @@
 """Convenience functions to define layout components."""
 
 from .plotly import Plotly
+from .echarts import Echarts
 
 __all__ = [f for f in dir() if f[0].isupper()]  # type: ignore

--- a/pynecone/components/graphing/echarts.py
+++ b/pynecone/components/graphing/echarts.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pynecone as pc
 from pynecone.components.component import Component
 from pynecone.components.tags import Tag
 from pynecone.var import Var
@@ -28,7 +27,7 @@ class Echarts(Component):
     """
     library = "echarts-for-react"
     tag = "EchartsForReact"
-    option: pc.Var[dict]
+    option: Var[dict]
     
 
     def _get_imports(self):

--- a/pynecone/components/graphing/echarts.py
+++ b/pynecone/components/graphing/echarts.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from pynecone.components.component import Component
-from pynecone.components.tags import Tag
 from pynecone.var import Var
 
 

--- a/pynecone/components/graphing/echarts.py
+++ b/pynecone/components/graphing/echarts.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pynecone as pc
+from pynecone.components.component import Component
+from pynecone.components.tags import Tag
+from pynecone.var import Var
+
+
+class Echarts(Component):
+    """A component that wraps echarts-for-react.
+    - echarts: https://echarts.apache.org/examples/en/index.html
+    - echarts-for-react: https://github.com/hustcc/echarts-for-react
+    """
+    library = "echarts-for-react"
+    tag = "EchartsForReact"
+    option: pc.Var[dict]
+    
+
+    def _get_imports(self):
+        return {}
+
+    def _get_custom_code(self) -> str:
+        return f'import {self.tag} from "{self.library}"'

--- a/pynecone/components/graphing/echarts.py
+++ b/pynecone/components/graphing/echarts.py
@@ -17,17 +17,33 @@
 
 from pynecone.components.component import Component
 from pynecone.var import Var
-
+from typing import Any, Dict
 
 class Echarts(Component):
     """A component that wraps echarts-for-react.
     - echarts: https://echarts.apache.org/examples/en/index.html
     - echarts-for-react: https://github.com/hustcc/echarts-for-react
     """
+
     library = "echarts-for-react"
     tag = "EchartsForReact"
-    option: Var[dict]
+
+    #
+    option: Var[Dict]#Var[dict] = {}
+
+    theme: Var[str]
+
+    notMerge: Var[bool]
+
+    lazyUpdate: Var[bool]
+
+    opts: Var[Dict]
     
+    onEvents: Var[Dict]
+
+    # onChartReady: Var
+
+
 
     def _get_imports(self):
         return {}


### PR DESCRIPTION
#200 
- Add Echarts Component to `./components/graphing/echarts.py`
- Add import to `./components/graphing/__init__.py`
- Add dependencies `"echarts": "^5.4.1", "echarts-for-react": "^3.0.2", "fast-deep-equal": "^3.1.3",` to `./.templates/web/package.json`


Notice:
1. `echarts` is under Apache License 2.0, please help with Pynecone overall LICENSE issues.
2. This initial component is included in a `pc.container()`, any better ways to follow?
3. Any further steps, please help me improve the code.
Thank you.

Usage Example:
```
"""Welcome to Pynecone! This file outlines the steps to create a basic app."""
from pcconfig import config
import pynecone as pc
from pynecone.components.graphing.echarts import Echarts
# from pynecone import echarts

docs_url = "https://pynecone.io/docs/getting-started/introduction"
filename = f"{config.app_name}/{config.app_name}.py"


class State(pc.State):
    """The app state."""

    pass

ec_option = {
    'xAxis': {'type': 'category', 'data': ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],},
    'yAxis': {'type': 'value',},
    'series': [
      { 'type': 'line', 'smooth': True, 'data': [820, 932, 901, 934, 1290, 1330, 1320],},
    ],
    'tooltip': {'trigger': 'axis',},
}

def index():
    return pc.center(
        pc.vstack(
            pc.heading("Welcome to Pynecone Echarts Graphing!", font_size="2em"),
            pc.container(
              pc.center(pc.text("box here"),),
              Echarts(option=ec_option,),
              bg="deepskyblue",
              width="100%",
              padding=5,
            ),
            spacing="1.5em",
            font_size="2em",
        ),
        padding_top="10%",
    )


# Add state and page to the app.
app = pc.App(state=State)
app.add_page(index)
app.compile()

```