### PR TITLE
fix to wait for router isReady on page load

### DIFF
--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -158,9 +158,12 @@ SOCKET = constants.SOCKET
 STATE = constants.STATE
 EVENTS = constants.EVENTS
 SET_RESULT = format_state_setter(RESULT)
+READY = f"const {{ isReady }} = {ROUTER};"
 USE_EFFECT = join(
     [
         "useEffect(() => {{",
+        "  if(!isReady)",
+        f"    return;",
         f"  if (!{SOCKET}.current) {{{{",
         f"    connect({SOCKET}, {{state}}, {RESULT}, {SET_RESULT}, {ROUTER}, {EVENT_ENDPOINT})",
         "  }}",

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -119,7 +119,8 @@ def compile_state(state: Type[State]) -> str:
     )
     router = templates.ROUTER
     socket = templates.SOCKET
-    return templates.join([synced_state, result, router, socket])
+    ready = templates.READY
+    return templates.join([synced_state, result, router, socket, ready])
 
 
 def compile_events(state: Type[State]) -> str:


### PR DESCRIPTION
fix needed to receive the content of `query` when the page initially load