### PR TITLE
Import event constructor in custom components

### DIFF
--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -81,7 +81,10 @@ def _compile_components(components: Set[CustomComponent]) -> str:
     Returns:
         The compiled components.
     """
-    imports = {"react": {"memo"}}
+    imports = {
+        "react": {"memo"},
+        f"/{constants.STATE_PATH}": {"E"},
+    }
     component_defs = []
 
     # Compile each component.


### PR DESCRIPTION
* required to construct events within the `components.js` file (for custom components)