### PR TITLE
Empty .web/pages directory on recompile

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -284,7 +284,7 @@ class App(Base):
         # Create the database models.
         Model.create_all()
 
-        #Empty the .web pages directory
+        # Empty the .web pages directory
         compiler.purge_web_pages_dir()
 
         # Compile the root document with base styles and fonts.

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -284,6 +284,9 @@ class App(Base):
         # Create the database models.
         Model.create_all()
 
+        #Empty the .web pages directory
+        compiler.purge_web_pages_dir()
+
         # Compile the root document with base styles and fonts.
         compiler.compile_document_root(self.stylesheets)
 

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -211,7 +211,6 @@ def compile_components(components: Set[CustomComponent]):
 
 
 def purge_web_pages_dir():
-    """Empty out .web directory.
-    """
-    template_files = ["_app.js","404.js"]
+    """Empty out .web directory."""
+    template_files = ["_app.js", "404.js"]
     utils.empty_dir(constants.WEB_PAGES_DIR, ignored=template_files)

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -213,4 +213,4 @@ def compile_components(components: Set[CustomComponent]):
 def purge_web_pages_dir():
     """Empty out .web directory."""
     template_files = ["_app.js", "404.js"]
-    utils.empty_dir(constants.WEB_PAGES_DIR, ignored=template_files)
+    utils.empty_dir(constants.WEB_PAGES_DIR, keep_files=template_files)

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -214,4 +214,4 @@ def purge_web_pages_dir():
     """Empty out .web directory.
     """
     template_files = ["_app.js","404.js"]
-    utils.empty_dir(constants.WEB_PAGES_DIR)
+    utils.empty_dir(constants.WEB_PAGES_DIR, ignored=template_files)

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -208,3 +208,9 @@ def compile_components(components: Set[CustomComponent]):
     # Compile the components.
     code = _compile_components(components)
     return output_path, code
+
+
+def purge_web_pages_dir():
+    """Empty out .web directory.
+    """
+    utils.empty_dir(constants.WEB_PAGES_DIR)

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -213,4 +213,5 @@ def compile_components(components: Set[CustomComponent]):
 def purge_web_pages_dir():
     """Empty out .web directory.
     """
+    template_files = ["_app.js","404.js"]
     utils.empty_dir(constants.WEB_PAGES_DIR)

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -305,8 +305,16 @@ def write_page(path: str, code: str):
     with open(path, "w") as f:
         f.write(code)
 
-def empty_dir(path):
-    """Empty directory
+def empty_dir(path, ignored=[]):
+    """Remove all files and folders in a directory except for the ignored file- or foldernames.
+
+    Args:
+        path (str): The path to the directory that will be emptied
+        excluded (list, optional): List of filenames or foldernames that will not be deleted. Defaults to [].
     """
-    utils.rm(path)
-    utils.mkdir(path)
+    directory_contents = os.listdir(path)
+    print(directory_contents)
+    for element in directory_contents:
+        if element not in ignored:
+            utils.rm(os.path.join(path, element))
+    

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -304,3 +304,9 @@ def write_page(path: str, code: str):
     utils.mkdir(os.path.dirname(path))
     with open(path, "w") as f:
         f.write(code)
+
+def empty_dir(path):
+    """Empty directory
+    """
+    utils.rm(path)
+    utils.mkdir(path)

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -313,7 +313,6 @@ def empty_dir(path, ignored=[]):
         excluded (list, optional): List of filenames or foldernames that will not be deleted. Defaults to [].
     """
     directory_contents = os.listdir(path)
-    print(directory_contents)
     for element in directory_contents:
         if element not in ignored:
             utils.rm(os.path.join(path, element))

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -306,14 +306,14 @@ def write_page(path: str, code: str):
         f.write(code)
 
 
-def empty_dir(path, ignored=[]):
-    """Remove all files and folders in a directory except for the ignored file- or foldernames.
+def empty_dir(path, keep_files=[]):
+    """Remove all files and folders in a directory except for the kept file- or foldernames.
 
     Args:
         path (str): The path to the directory that will be emptied
-        excluded (list, optional): List of filenames or foldernames that will not be deleted. Defaults to [].
+        keep_files (list, optional): List of filenames or foldernames that will not be deleted. Defaults to [].
     """
     directory_contents = os.listdir(path)
     for element in directory_contents:
-        if element not in ignored:
+        if element not in keep_files:
             utils.rm(os.path.join(path, element))

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -305,6 +305,7 @@ def write_page(path: str, code: str):
     with open(path, "w") as f:
         f.write(code)
 
+
 def empty_dir(path, ignored=[]):
     """Remove all files and folders in a directory except for the ignored file- or foldernames.
 
@@ -316,4 +317,3 @@ def empty_dir(path, ignored=[]):
     for element in directory_contents:
         if element not in ignored:
             utils.rm(os.path.join(path, element))
-    


### PR DESCRIPTION
Empty the .web/pages directory on recompile so that old pages that don't exist anymore in the python code get removed.