### PR TITLE
fix: validate event

### DIFF
--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -157,9 +157,10 @@ class Component(Base, ABC):
         Raises:
             ValueError: If the value is not a valid event chain.
         """
-        # If it's already an event chain, return it.
-        if isinstance(value, EventChain):
-            return value
+        # If it's a custom component and var, return it.
+        if isinstance(self, CustomComponent):
+            if isinstance(value, Var):
+                return value
 
         arg = self.get_controlled_value()
 

--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -158,7 +158,7 @@ class Component(Base, ABC):
             ValueError: If the value is not a valid event chain.
         """
         # If it's already an event chain, return it.
-        if isinstance(value, Var):
+        if isinstance(value, EventChain):
             return value
 
         arg = self.get_controlled_value()


### PR DESCRIPTION
Resolve: #310 

Validate EventChain explicitly, so other types will be caught as a ValueError

> ValueError: Invalid event chain: {state. some_var}