### PR TITLE
Add and use `pc.list` to have list mutation detection

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -13,7 +13,7 @@ from redis import Redis
 from pynecone import constants, utils
 from pynecone.base import Base
 from pynecone.event import Event, EventHandler, window_alert
-from pynecone.var import BaseVar, ComputedVar, PcList, Var
+from pynecone.var import BaseVar, ComputedVar, PCList, Var
 
 Delta = Dict[str, Any]
 
@@ -636,7 +636,7 @@ def _convert_mutable_datatypes(
                 field_value[index], reassign_field, field_name
             )
 
-        field_value = PcList(
+        field_value = PCList(
             field_value, reassign_field=reassign_field, field_name=field_name
         )
 

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -76,13 +76,14 @@ class State(Base, ABC):
                     field.name,
                     PcList(
                         getattr(self, field.name),
-                        reassign_field=self._reassign_field,
-                        field_name=field.name,
+                        reassign_field=lambda: self._reassign_field(field.name),
                     ),
                 )
 
     def _reassign_field(self, field_name: str):
         """Reassign the given field.
+
+        Primarily for mutation in fields of mutable data types.
 
         Args:
             field_name (str): The name of the field we want to reassign

--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -756,8 +756,7 @@ class PcList(list):
     def __init__(
         self,
         original_list: list,
-        reassign_field: Callable | None = None,
-        field_name: str | None = None,
+        reassign_field: Callable = lambda: None,
     ):
         """Initialize PcList.
 
@@ -767,18 +766,9 @@ class PcList(list):
                 The method in the parent state to reassign the field.
             field_name (str): The field name of the list in the parent state.
         """
-        self._reassign_field, self._field_name = None, None
-
-        if reassign_field is not None and field_name is not None:
-            self._reassign_field = reassign_field
-            self._field_name = field_name
+        self._reassign_field = reassign_field
 
         super().__init__(original_list)
-
-    def _parent_state_reassign_field(self):
-        """Reassign the field in the parent state."""
-        if self._reassign_field is not None and self._field_name is not None:
-            self._reassign_field(self._field_name)
 
     def append(self, *args, **kargs):
         """Append.
@@ -788,7 +778,7 @@ class PcList(list):
             kargs: The kwargs passed.
         """
         super().append(*args, **kargs)
-        self._parent_state_reassign_field()
+        self._reassign_field()
 
     def __setitem__(self, *args, **kargs):
         """Set item.
@@ -798,7 +788,7 @@ class PcList(list):
             kargs: The kwargs passed.
         """
         super().__setitem__(*args, **kargs)
-        self._parent_state_reassign_field()
+        self._reassign_field()
 
     def __delitem__(self, *args, **kargs):
         """Delete item.
@@ -808,4 +798,4 @@ class PcList(list):
             kargs: The kwargs passed.
         """
         super().__delitem__(*args, **kargs)
-        self._parent_state_reassign_field()
+        self._reassign_field()

--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -762,9 +762,9 @@ class PcList(list):
 
         Args:
             original_list (list): The original list
-            reassign_field (function | None):
+            reassign_field (Callable):
                 The method in the parent state to reassign the field.
-            field_name (str): The field name of the list in the parent state.
+                Default to be a no-op function
         """
         self._reassign_field = reassign_field
 

--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -755,18 +755,20 @@ class PcList(list):
 
     def __init__(
         self,
-        original_list: list,
-        reassign_field: Callable = lambda: None,
+        original_list: List,
+        reassign_field: Callable = lambda _field_name: None,
+        field_name: str = "",
     ):
         """Initialize PcList.
 
         Args:
-            original_list (list): The original list
+            original_list (List): The original list
             reassign_field (Callable):
                 The method in the parent state to reassign the field.
                 Default to be a no-op function
+            field_name (str): the name of field in the parent state
         """
-        self._reassign_field = reassign_field
+        self._reassign_field = lambda: reassign_field(field_name)
 
         super().__init__(original_list)
 
@@ -798,4 +800,44 @@ class PcList(list):
             kargs: The kwargs passed.
         """
         super().__delitem__(*args, **kargs)
+        self._reassign_field()
+
+    def clear(self, *args, **kargs):
+        """Remove all item from the list.
+
+        Args:
+            args: The args passed.
+            kargs: The kwargs passed.
+        """
+        super().clear(*args, **kargs)
+        self._reassign_field()
+
+    def extend(self, *args, **kargs):
+        """Add all item of a list to the end of the list.
+
+        Args:
+            args: The args passed.
+            kargs: The kwargs passed.
+        """
+        super().extend(*args, **kargs)
+        self._reassign_field()
+
+    def pop(self, *args, **kargs):
+        """Remove an element.
+
+        Args:
+            args: The args passed.
+            kargs: The kwargs passed.
+        """
+        super().pop(*args, **kargs)
+        self._reassign_field()
+
+    def remove(self, *args, **kargs):
+        """Remove an element.
+
+        Args:
+            args: The args passed.
+            kargs: The kwargs passed.
+        """
+        super().remove(*args, **kargs)
         self._reassign_field()

--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -750,7 +750,7 @@ class ComputedVar(property, Var):
         return Any
 
 
-class PcList(list):
+class PCList(list):
     """A custom list that pynecone can detect its mutation."""
 
     def __init__(
@@ -759,7 +759,7 @@ class PcList(list):
         reassign_field: Callable = lambda _field_name: None,
         field_name: str = "",
     ):
-        """Initialize PcList.
+        """Initialize PCList.
 
         Args:
             original_list (List): The original list

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -222,19 +222,6 @@ def list_mutation_state():
     return TestState()
 
 
-async def _test_event_delta(state, event_name, expected_delta):
-    result = await state.process(
-        Event(
-            token="fake-token",
-            name=event_name,
-            router_data={"pathname": "/", "query": {}},
-            payload={},
-        )
-    )
-
-    assert result.delta == expected_delta
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "event_tuples",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -161,6 +161,12 @@ def test_set_and_get_state(TestState: Type[State]):
 
 @pytest.fixture
 def list_mutation_state():
+    """A fixture to create a state with list mutation features.
+
+    Returns:
+        A state with list mutation features.
+    """
+
     class AppState(State):
         """The app state."""
 
@@ -206,6 +212,10 @@ async def test_list_mutation_detection(
 ):
     """Test list mutation detection
     when reassignment is not explicitly included in the logic.
+
+    Args:
+        event_tuples: From parametrization.
+        list_mutation_state: A state with list mutation features.
     """
     for event_name, expected_friends_in_delta in event_tuples:
         result = await list_mutation_state.process(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import List, Tuple, Type
 
 import pytest
 
@@ -202,7 +202,7 @@ def list_mutation_state():
     ],
 )
 async def test_list_mutation_detection(
-    event_tuples: list[tuple[str, list[str]]], list_mutation_state: State
+    event_tuples: List[Tuple[str, List[str]]], list_mutation_state: State
 ):
     """Test list mutation detection
     when reassignment is not explicitly included in the logic.


### PR DESCRIPTION
To add and use `pc.list`/`PcList` to have list mutation detection.

It's not as straightforward as I thought. Or is my approach too complicated?

For #334. `pc.dict` would be in another PR.