### PR TITLE
Use ReconnectingWebSocket instead of vanilla WebSocket

### DIFF
--- a/pynecone/.templates/web/package.json
+++ b/pynecone/.templates/web/package.json
@@ -24,6 +24,7 @@
     "react-markdown": "^8.0.3",
     "react-plotly.js": "^2.6.0",
     "react-syntax-highlighter": "^15.5.0",
+    "reconnecting-websocket": "^4.4.0",
     "rehype-katex": "^6.0.2",
     "rehype-raw": "^6.1.1",
     "remark-gfm": "^3.0.1",

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -4,7 +4,7 @@
 let token;
 
 // Key for the token in the session storage.
-const TOKEN_KEY = "token";
+const TOKEN_KEY = "token"; 
 
 /**
  * Generate a UUID (Used for session tokens).

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -4,7 +4,7 @@
 let token;
 
 // Key for the token in the session storage.
-const TOKEN_KEY = "token"; 
+const TOKEN_KEY = "token";
 
 /**
  * Generate a UUID (Used for session tokens).

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -136,7 +136,7 @@ export const updateState = async (state, setState, result, setResult, router, so
  */
 export const connect = async (socket, state, setState, result, setResult, router, endpoint) => {
   // Create the socket.
-  socket.current = new WebSocket(endpoint);
+  socket.current = new ReconnectingWebSocket(endpoint);
 
   // Once the socket is open, hydrate the page.
   socket.current.onopen = () => {

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -1,4 +1,5 @@
 // State management for Pynecone web apps.
+import ReconnectingWebSocket from 'reconnecting-websocket';
 
 // Global variable to hold the token.
 let token;


### PR DESCRIPTION
Currently Pynecone doesn't handle websocket onclose events. Using reconnecting-websocket handles such events automatically. 

Note that this does not 100% solve the issues which arise on mobile devices, especially iPhones which aggressively control network connection to preserve battery.