### PR TITLE
error message for invalid event handler signature

### DIFF
--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -1127,8 +1127,15 @@ def get_handler_args(event_spec: EventSpec, arg: Var) -> Tuple[Tuple[str, str], 
 
     Returns:
         The handler args.
+
+    Raises:
+        TypeError: If the event handler has an invalid signature.
     """
     args = inspect.getfullargspec(event_spec.handler.fn).args
+    if len(args) < 2:
+        raise TypeError(
+            f"Event handler has an invalid signature, needed a method with a parameter, got {event_spec.handler}."
+        )
     return event_spec.args if len(args) > 2 else ((args[1], arg.name),)
 
 


### PR DESCRIPTION
Resolve: #349 

Couldn't get enough context inside this util function, so just let a developer know which function used is invalid.

It prints out,
> TypeError: Event handler has an invalid signature, needed a method with a parameter, got fn=<function State.change_text at 0x113131670>.