### PR TITLE
feat: multiple styles for components

### DIFF
--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -130,9 +130,14 @@ class Component(Base, ABC):
             del kwargs[key]
 
         # Add style props to the component.
+        style = kwargs.get("style", {})
+        if isinstance(style, List):
+            # Merge styles, the later ones overriding keys in the earlier ones.
+            style = {k: v for style_dict in style for k, v in style_dict.items()}
+
         kwargs["style"] = Style(
             {
-                **kwargs.get("style", {}),
+                **style,
                 **{attr: value for attr, value in kwargs.items() if attr not in fields},
             }
         )


### PR DESCRIPTION
Resolve: #353 

looping through a list and overwriting earlier ones.

This renders a yellow box:
```python
def index():
    return pc.box("box", style=[{"background_color": "orange"}, {"background_color": "yellow"}])

app = pc.App(state=State, style={pc.Box: {"background_color": "red"}})
app.add_page(index)
app.compile()
```