### PR TITLE
Dynamically add vars to a State

### DIFF
--- a/pynecone/base.py
+++ b/pynecone/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Dict, TypeVar
 
 import pydantic
+from pydantic.fields import ModelField
 
 # Typevar to represent any class subclassing Base.
 PcType = TypeVar("PcType")
@@ -54,6 +55,25 @@ class Base(pydantic.BaseModel):
             The fields of the object.
         """
         return cls.__fields__
+
+    @classmethod
+    def add_field(cls, var: Any, default_value: Any):
+        """Add a pydantic field after class definition.
+
+        Used by State.add_var() to correctly handle the new variable.
+
+        Args:
+            var: The variable to add a pydantic field for.
+            default_value: The default value of the field
+        """
+        new_field = ModelField.infer(
+            name=var.name,
+            value=default_value,
+            annotation=var.type_,
+            class_validators=None,
+            config=cls.__config__,
+        )
+        cls.__fields__.update({var.name: new_field})
 
     def get_value(self, key: str) -> Any:
         """Get the value of a field.

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -279,8 +279,8 @@ class State(Base, ABC):
 
         Args:
             name (str): The name of the variable
-            type_ (any): The type of the variable
-            default_value (any): The default value of the variable
+            type_ (Any): The type of the variable
+            default_value (Any): The default value of the variable
 
         Raises:
             NameError: if a variable of this name already exists

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -638,3 +638,20 @@ def test_get_query_params(test_state):
     test_state.router_data = {RouteVar.QUERY: params}
 
     assert test_state.get_query_params() == params
+
+
+def test_add_var(test_state):
+    test_state.add_var("dynamic_int", int, 42)
+    assert test_state.dynamic_int == 42
+
+    test_state.add_var("dynamic_list", List[int], [5, 10])
+    assert test_state.dynamic_list == [5, 10]
+    assert getattr(test_state, "dynamic_list") == [5, 10]
+
+    # how to test that one?
+    # test_state.dynamic_list.append(15)
+    # assert test_state.dynamic_list == [5, 10, 15]
+
+    test_state.add_var("dynamic_dict", Dict[str, int], {"k1": 5, "k2": 10})
+    assert test_state.dynamic_dict == {"k1": 5, "k2": 10}
+    assert getattr(test_state, "dynamic_dict") == {"k1": 5, "k2": 10}


### PR DESCRIPTION
## Description:
Add a new classmethod `add_var` to `pc.State` allowing to add dynamically a var to a State, that can then be used in the same way as a var defined statically.

To add a variable called `"dynamic_var"` of type `int` with default value `42`: 
```
State.add_var("dynamic_var", int, 42)
```
This variable can then be accessed in two way : 
```
State.dynamic_var # access it the same way you would a static var
getattr(State, "dynamic_var") # access it like this if the name of the variable to access change at runtime
```

Closes #303 #346 

> Note: I added some basic tests for the new method but they could probably be improved.
 
## Checklist:
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
