### PR TITLE
allow backend variables starting with _

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -33,6 +33,9 @@ class State(Base, ABC):
     # Vars inherited by the parent state.
     inherited_vars: ClassVar[Dict[str, Var]] = {}
 
+    # Backend vars that are never sent to the client.
+    backend_vars: ClassVar[Dict[str, Any]] = {}
+
     # The parent state.
     parent_state: Optional[State] = None
 

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -1231,5 +1231,17 @@ def get_redis() -> Optional[Redis]:
     return Redis(host=redis_url, port=int(redis_port), db=0)
 
 
+def is_backend_variable(name: str) -> bool:
+    """Check if this variable name correspond to a backend variable.
+
+    Args:
+        name (str): The name of the variable to check
+
+    Returns:
+        bool: The result of the check
+    """
+    return name.startswith("_") and not name.startswith("__")
+
+
 # Store this here for performance.
 StateBases = get_base_class(StateVar)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,3 +226,15 @@ def test_setup_frontend(tmp_path, mocker):
     assert web_folder.exists()
     assert web_public_folder.exists()
     assert (web_public_folder / "favicon.ico").exists()
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    [
+        ("_hidden", True),
+        ("not_hidden", False),
+        ("__dundermethod__", False),
+    ],
+)
+def test_is_backend_variable(input, output):
+    assert utils.is_backend_variable(input) == output


### PR DESCRIPTION
## Description
Allow the use of variables starting with _ within a State.
Those variable will be considered as backend variables, and will never be sent to the frontend.
You can read/write a backend variable from within an event handler.

Backend variables can also be used within a computed var to generate a value that will be sent to the frontend.  

(This is a non-breaking change because pydantic already ignored any variable starting with _)

Closes #307 

> Note: I added test for the utils function `is_backend_variable()` but I'm not too sure how to test the backend variable, I'm open to suggestions if I need to add them.

## Checklist

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

