### PR TITLE
Make db_url optional

### DIFF
--- a/docker-example/README.md
+++ b/docker-example/README.md
@@ -1,10 +1,13 @@
 # Pynecone Container Image Build
+
 This example describes how to create and use a container image for Pynecone with your own code.
 
 ## Update Requirements
+
 The `requirements.txt` includes the pynecone-io package which is need to install Pynecone framework. If you use additional packages in your project you have add this in the `requirements.txt` first. Copy the `Dockerfile` and the `requirements.txt` file in your project folder.
 
 ## Customize Pynecone Config
+
 The `pcconfig.py` includes the configuration of your Pynecone service. Edit the file like the following configuration. If you want to use a custom database you can set the endpoint in this file.
 
 ```python
@@ -18,7 +21,8 @@ config = pc.Config(
 )
 ```
 
-## Build Pyonecone Container Image
+## Build Pynecone Container Image
+
 To build your container image run the following command:
 
 ```bash
@@ -26,6 +30,7 @@ docker build -t pynecone-project:latest .
 ```
 
 ## Start Container Service
+
 Finally, you can start your Pynecone container service as follows:
 
 ```bash

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -302,7 +302,8 @@ class App(Base):
             return
 
         # Create the database models.
-        Model.create_all()
+        if config.db_url is not None:
+            Model.create_all()
 
         # Empty the .web pages directory
         compiler.purge_web_pages_dir()

--- a/pynecone/config.py
+++ b/pynecone/config.py
@@ -22,7 +22,7 @@ class Config(Base):
     api_url: str = constants.API_URL
 
     # The database url.
-    db_url: str = constants.DB_URL
+    db_url: Optional[str] = constants.DB_URL
 
     # The redis url.
     redis_url: Optional[str] = None

--- a/pynecone/model.py
+++ b/pynecone/model.py
@@ -13,6 +13,8 @@ def get_engine():
         The database engine.
     """
     url = utils.get_config().db_url
+    if url is None:
+        raise ValueError("No database url in config")
     return sqlmodel.create_engine(url, echo=False)
 
 

--- a/pynecone/model.py
+++ b/pynecone/model.py
@@ -11,6 +11,9 @@ def get_engine():
 
     Returns:
         The database engine.
+
+    Raises:
+        ValueError: If the database url is None.
     """
     url = utils.get_config().db_url
     if url is None:


### PR DESCRIPTION
This pull request allows to set db_url to None to prevent the creation of the sqlite file and the use of SQLAlchemy within the applicaton in general.
I have let the default of db_url as it is, I think it's best to let it this way.