### PR TITLE
Fix args format in dynamic route

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -357,11 +357,14 @@ async def process(
     # Get the state for the session.
     state = app.state_manager.get_state(event.token)
 
+    formatted_params = utils.format_query_params(event.router_data)
+
     # Pass router_data to the state of the App.
     state.router_data = event.router_data
     # also pass router_data to all substates
     for _, substate in state.substates.items():
         substate.router_data = event.router_data
+    state.router_data[constants.RouteVar.QUERY] = formatted_params
     state.router_data[constants.RouteVar.CLIENT_TOKEN] = event.token
     state.router_data[constants.RouteVar.SESSION_ID] = sid
     state.router_data[constants.RouteVar.HEADERS] = headers

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -1066,6 +1066,19 @@ def format_event(event_spec: EventSpec) -> str:
     return f"E(\"{format_event_handler(event_spec.handler)}\", {wrap(args, '{')})"
 
 
+def format_query_params(router_data: Dict[str, Any]):
+    """Convert back query params name to python-friendly case.
+
+    Args:
+        router_data: the router_data dict containing the query params
+
+    Returns:
+        The reformatted query params
+    """
+    params = router_data[constants.RouteVar.QUERY]
+    return {k.replace("-", "_"): v for k, v in params.items()}
+
+
 USED_VARIABLES = set()
 
 

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -1101,7 +1101,7 @@ def format_event(event_spec: EventSpec) -> str:
     return f"E(\"{format_event_handler(event_spec.handler)}\", {wrap(args, '{')})"
 
 
-def format_query_params(router_data: Dict[str, Any]):
+def format_query_params(router_data: Dict[str, Any]) -> Dict[str, str]:
     """Convert back query params name to python-friendly case.
 
     Args:


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

With dynamic route, due to some conversion that occurs at compile time, if you declare a route arg like `my_arg`,
it will be added in `router_data['query']` under the key `"my-arg"`.

To avoid the problems occuring due to this conversion, when we assign `router_data` to the state, we format the keys in query to get back `my_arg`. 


