### PR TITLE
Fix pc export use the wrong backend url

### DIFF
--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -158,8 +158,18 @@ def export(
     backend: bool = typer.Option(
         True, "--frontend-only", help="Export only frontend.", show_default=False
     ),
+    for_pc_deploy: bool = typer.Option(
+        False,
+        "--for-pc-deploy",
+        help="Whether export the app for Pynecone Deploy Service.",
+    ),
 ):
     """Export the app to a zip file."""
+    if for_pc_deploy:
+        # Get the app config and modify the api_url base on username and app_name.
+        config = utils.get_config()
+        config.api_url = utils.get_production_backend_url()
+
     # Compile the app in production mode and export it.
     utils.console.rule("[bold]Compiling production app and preparing for export.")
     app = utils.get_app().app

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -160,10 +160,6 @@ def export(
     ),
 ):
     """Export the app to a zip file."""
-    # Get the app config.
-    config = utils.get_config()
-    config.api_url = utils.get_production_backend_url()
-
     # Compile the app in production mode and export it.
     utils.console.rule("[bold]Compiling production app and preparing for export.")
     app = utils.get_app().app


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Closed #487.

This Pull Request let `pc export` command use the right api_url defined in `pcconfig.py`.

It is a temp solution that will break the behavior of Pynecone Deploy (Alpha), but due to this feature has not published to public and only use for Pynecone Main Site and Example Site, the risk is affordable.