### PR TITLE
Add support for pages to return iterables of components

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -14,6 +14,7 @@ from pynecone.event import Event, EventHandler
 from pynecone.middleware import HydrateMiddleware, Middleware
 from pynecone.model import Model
 from pynecone.state import DefaultState, Delta, State, StateManager, StateUpdate
+from pynecone.components.layout import Fragment
 
 # Define custom types.
 ComponentCallable = Callable[[], Component]
@@ -217,7 +218,10 @@ class App(Base):
 
         # Generate the component if it is a callable.
         component = component if isinstance(component, Component) else component()
-
+        
+        if isinstance(component, tuple):
+            component = Fragment(*component)
+        
         # Add meta information to the component.
         compiler_utils.add_meta(
             component, title=title, image=image, description=description

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -223,10 +223,9 @@ class App(Base):
         if not isinstance(component, Component):    
             try:
                 iter(component)
+                component = Fragment(children = [i for i in component])
             except:
                 pass
-            else:
-                component = Fragment(children = [i for i in component])
         
         # Add meta information to the component.
         compiler_utils.add_meta(

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -219,8 +219,14 @@ class App(Base):
         # Generate the component if it is a callable.
         component = component if isinstance(component, Component) else component()
         
-        if isinstance(component, tuple):
-            component = Fragment(*component)
+        # If the returned component is iterable, wrap it in a Fragment component
+        if not isinstance(component, Component):    
+            try:
+                iter(component)
+            except:
+                pass
+            else:
+                component = Fragment(children = [i for i in component])
         
         # Add meta information to the component.
         compiler_utils.add_meta(


### PR DESCRIPTION
Adds support for pages to be able to return tuples or any iterable of components, such as
```
def index()
  return pc.text("Hello"), pc.text("World)
```
Wrapping them in a Fragment object.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.
Add support for pages to return iterables of components
    b. Describe your changes.
Adds support for pages to be able to return tuples or any iterable of components.
    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
closes #492
