### PR TITLE
Fix a small error in the highlevel API of list.py

### DIFF
--- a/pynecone/components/datadisplay/list.py
+++ b/pynecone/components/datadisplay/list.py
@@ -34,7 +34,7 @@ class List(ChakraComponent):
         if len(children) == 0:
             children = []
             for item in items or []:
-                children.append(ListItem.create(*item))
+                children.append(ListItem.create(item))
         return super().create(*children, **props)
 
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Ran into a small error with `pc.list()` high level API when passing `list[Components]` to `items`


