### PR TITLE
Add class name propety to component

### DIFF
--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -47,6 +47,9 @@ class Component(Base, ABC):
     # The id for the component.
     id: Any = None
 
+    # The class name for the component.
+    class_name: Any = None
+
     @classmethod
     def __init_subclass__(cls, **kwargs):
         """Set default properties.
@@ -144,6 +147,11 @@ class Component(Base, ABC):
                 **{attr: value for attr, value in kwargs.items() if attr not in fields},
             }
         )
+
+        # Convert class_name to str if it's list
+        class_name = kwargs.get("class_name", "")
+        if isinstance(class_name, (List, tuple)):
+            kwargs["class_name"] = " ".join(class_name)
 
         # Construct the component.
         super().__init__(*args, **kwargs)
@@ -370,7 +378,11 @@ class Component(Base, ABC):
         tag = self._render()
         return str(
             tag.add_props(
-                **self.event_triggers, key=self.key, sx=self.style, id=self.id
+                **self.event_triggers,
+                key=self.key,
+                sx=self.style,
+                id=self.id,
+                className=self.class_name,
             ).set(
                 contents=utils.join(
                     [str(tag.contents)] + [child.render() for child in self.children]

--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -382,7 +382,7 @@ class Component(Base, ABC):
                 key=self.key,
                 sx=self.style,
                 id=self.id,
-                className=self.class_name,
+                class_name=self.class_name,
             ).set(
                 contents=utils.join(
                     [str(tag.contents)] + [child.render() for child in self.children]


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Description
Add class_name property to component.
We can add class_name to at any component.

This change add class name to the component.
Will not break default class name, like chackra ones.

### Usage
class_name property covers type of str, List and tuple.

#### str
python code.
```py
pc.text("new class", class_name="class-name-1")
```

js code.
```js
<Text ClassName="class-name-1">{`new class`}</Text>
```
---
#### List
python code.
```py
pc.text("new class", class_name=["class-name-1", "class-name-list"])
```

js code.
```js
<Text ClassName="class-name-1 class-name-list">{`new class`}</Text>
```

---
#### tuple
python code.
```py
pc.text("new class", class_name=("class-name-1", "class-name-tuple"))
```

js code.
```js
<Text ClassName="class-name-1 class-name-tuple">{`new class`}</Text>
```

close #539
