### PR TITLE
Windows production mode command

### DIFF
--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -77,6 +77,7 @@ BACKEND_HOST = "0.0.0.0"
 TIMEOUT = 120
 # The command to run the backend in production mode.
 RUN_BACKEND_PROD = f"gunicorn --worker-class uvicorn.workers.UvicornH11Worker --preload --timeout {TIMEOUT} --log-level critical".split()
+RUN_BACKEND_PROD_WINDOWS = f"uvicorn --timeout-keep-alive {TIMEOUT}".split()
 
 # Compiler variables.
 # The extension for compiled Javascript files.

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -799,31 +799,34 @@ def run_backend_prod(
     setup_backend()
 
     num_workers = get_num_workers()
-    command = []
-    if platform.system() == "Windows":
-        command += constants.RUN_BACKEND_PROD_WINDOWS + [
+    command = (
+        constants.RUN_BACKEND_PROD_WINDOWS
+        + [
             "--host",
             "0.0.0.0",
             "--port",
             str(port),
-            "--workers",
-            str(num_workers),
             "--log-level",
             loglevel,
             f"{app_name}:{constants.APP_VAR}",
         ]
-    else:
-        command += constants.RUN_BACKEND_PROD + [
+        if platform.system() == "Windows"
+        else constants.RUN_BACKEND_PROD
+        + [
             "--bind",
             f"0.0.0.0:{port}",
-            "--workers",
-            str(num_workers),
             "--threads",
             str(num_workers),
             "--log-level",
             str(loglevel),
             f"{app_name}:{constants.APP_VAR}()",
         ]
+    )
+
+    command += [
+        "--workers",
+        str(num_workers),
+    ]
     subprocess.run(command)
 
 

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -799,17 +799,31 @@ def run_backend_prod(
     setup_backend()
 
     num_workers = get_num_workers()
-    command = constants.RUN_BACKEND_PROD + [
-        "--bind",
-        f"0.0.0.0:{port}",
-        "--workers",
-        str(num_workers),
-        "--threads",
-        str(num_workers),
-        "--log-level",
-        str(loglevel),
-        f"{app_name}:{constants.APP_VAR}()",
-    ]
+    command = []
+    if platform.system() == "Windows":
+        command += constants.RUN_BACKEND_PROD_WINDOWS + [
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+            "--workers",
+            str(num_workers),
+            "--log-level",
+            loglevel,
+            f"{app_name}:{constants.APP_VAR}",
+        ]
+    else:
+        command += constants.RUN_BACKEND_PROD + [
+            "--bind",
+            f"0.0.0.0:{port}",
+            "--workers",
+            str(num_workers),
+            "--threads",
+            str(num_workers),
+            "--log-level",
+            str(loglevel),
+            f"{app_name}:{constants.APP_VAR}()",
+        ]
     subprocess.run(command)
 
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Add production mode command for Windows PC.
We can not use Gunicorn on Windows now, so I add Uvicorn command.
I kept the code for the Linux-based machine because it's not better to use only Uvicorn than Gunicorn.
