### PR TITLE
[Fix issue 563] Add meta arg to page_add method

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -199,7 +199,7 @@ class App(Base):
         image=constants.DEFAULT_IMAGE,
         on_load: Optional[EventHandler] = None,
         path: Optional[str] = None,
-        meta: Optional[List[Dict]] = None,
+        meta: List[Dict] = constants.DEFAULT_META_LIST,
     ):
         """Add a page to the app.
 
@@ -287,7 +287,12 @@ class App(Base):
                 )
 
     def add_custom_404_page(
-        self, component, title=None, image=None, description=None, meta=None
+        self,
+        component,
+        title=None,
+        image=None,
+        description=None,
+        meta=constants.DEFAULT_META_LIST,
     ):
         """Define a custom 404 page for any url having no match.
 

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -199,6 +199,7 @@ class App(Base):
         image=constants.DEFAULT_IMAGE,
         on_load: Optional[EventHandler] = None,
         path: Optional[str] = None,
+        meta: Optional[List[Dict]] = None,
     ):
         """Add a page to the app.
 
@@ -213,6 +214,7 @@ class App(Base):
             description: The description of the page.
             image: The image to display on the page.
             on_load: The event handler that will be called each time the page load.
+            meta: The metadata of the page.
         """
         if path is not None:
             utils.deprecate(
@@ -238,7 +240,7 @@ class App(Base):
 
         # Add meta information to the component.
         compiler_utils.add_meta(
-            component, title=title, image=image, description=description
+            component, title=title, image=image, description=description, meta=meta
         )
 
         # Format the route.
@@ -284,7 +286,9 @@ class App(Base):
                     f"You cannot use multiple catchall for the same dynamic route ({route} !== {new_route})"
                 )
 
-    def add_custom_404_page(self, component, title=None, image=None, description=None):
+    def add_custom_404_page(
+        self, component, title=None, image=None, description=None, meta=None
+    ):
         """Define a custom 404 page for any url having no match.
 
         If there is no page defined on 'index' route, add the 404 page to it.
@@ -295,6 +299,7 @@ class App(Base):
             title: The title of the page.
             description: The description of the page.
             image: The image to display on the page.
+            meta: The metadata of the page.
         """
         title = title or constants.TITLE_404
         image = image or constants.FAVICON_404
@@ -303,7 +308,7 @@ class App(Base):
         component = component if isinstance(component, Component) else component()
 
         compiler_utils.add_meta(
-            component, title=title, image=image, description=description
+            component, title=title, image=image, description=description, meta=meta
         )
 
         froute = utils.format_route

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -279,7 +279,7 @@ def get_components_path() -> str:
 
 
 def add_meta(
-    page: Component, title: str, image: str, description: str, meta: List[Dict] | None
+    page: Component, title: str, image: str, description: str, meta: List[Dict]
 ) -> Component:
     """Add metadata to a page.
 
@@ -293,7 +293,7 @@ def add_meta(
     Returns:
         The component with the metadata added.
     """
-    meta_tags = [Meta.create(**item) for item in meta] if meta is not None else []
+    meta_tags = [Meta.create(**item) for item in meta]
 
     page.children.append(
         Head.create(

--- a/pynecone/compiler/utils.py
+++ b/pynecone/compiler/utils.py
@@ -16,6 +16,7 @@ from pynecone.components.base import (
     Image,
     Link,
     Main,
+    Meta,
     Script,
     Title,
 )
@@ -277,7 +278,9 @@ def get_components_path() -> str:
     return os.path.join(constants.WEB_UTILS_DIR, "components" + constants.JS_EXT)
 
 
-def add_meta(page: Component, title: str, image: str, description: str) -> Component:
+def add_meta(
+    page: Component, title: str, image: str, description: str, meta: List[Dict] | None
+) -> Component:
     """Add metadata to a page.
 
     Args:
@@ -285,15 +288,19 @@ def add_meta(page: Component, title: str, image: str, description: str) -> Compo
         title: The title of the page.
         image: The image for the page.
         description: The description of the page.
+        meta: The metadata list.
 
     Returns:
         The component with the metadata added.
     """
+    meta_tags = [Meta.create(**item) for item in meta] if meta is not None else []
+
     page.children.append(
         Head.create(
             Title.create(title),
             Description.create(content=description),
             Image.create(content=image),
+            *meta_tags,
         )
     )
 

--- a/pynecone/components/base/__init__.py
+++ b/pynecone/components/base/__init__.py
@@ -4,4 +4,4 @@ from .body import Body
 from .document import ColorModeScript, DocumentHead, Html, Main, Script
 from .head import Head
 from .link import Link
-from .meta import Description, Image, Title
+from .meta import Description, Image, Meta, Title

--- a/pynecone/components/base/meta.py
+++ b/pynecone/components/base/meta.py
@@ -30,12 +30,21 @@ class Meta(Component):
 
     tag = "meta"
 
+    # The description of character encoding.
+    char_set: Optional[str] = None
+
+    # The value of meta.
+    content: Optional[str] = None
+
+    # The name of metadata.
+    name: Optional[str] = None
+
+    # The type of metadata value.
+    property: Optional[str] = None
+
 
 class Description(Meta):
     """A component that displays the title of the current page."""
-
-    # The description of the page.
-    content: Optional[str] = None
 
     # The type of the description.
     name: str = "description"
@@ -43,9 +52,6 @@ class Description(Meta):
 
 class Image(Meta):
     """A component that displays the title of the current page."""
-
-    # The image of the page.
-    content: Optional[str] = None
 
     # The type of the image.
     property: str = "og:image"

--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -124,6 +124,8 @@ DEFAULT_TITLE = "Pynecone App"
 DEFAULT_DESCRIPTION = "A Pynecone app."
 # The default image to show for Pynecone apps.
 DEFAULT_IMAGE = "favicon.ico"
+# The default meta list to show for Pynecone apps.
+DEFAULT_META_LIST = []
 
 
 # The gitignore file.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Description
As mentioned in issue, I add meta key to `add_page` function.

### Usage
Make meta variable which is a list of dictionary, and pass it to the method.

python
```py

meta = [
    {"name": "theme_color", "content": "#FFFFFF"},
    {"char_set": "UTF-8"},
    {"property": "og:url", "content": "url"
]

app.add_page(index, meta=meta)

```

compiled js
```js
<NextHead><meta name="theme_color"

content="#FFFFFF"/>

<meta charSet="UTF-8"/>

<meta property="og:url" content="url"/></NextHead>
```

### Issue
Close #563.