### PR TITLE
fix needed following the PR that changed Icon usage

### DIFF
--- a/pynecone/components/overlay/alertdialog.py
+++ b/pynecone/components/overlay/alertdialog.py
@@ -102,7 +102,7 @@ class AlertDialog(ChakraComponent):
             if props.get("on_close"):
                 # get user defined close button or use default one
                 if not close_button:
-                    close_button = Icon.create(tag="CloseIcon")
+                    close_button = Icon.create(tag="close")
                 contents.append(AlertDialogCloseButton.create(close_button))
             elif close_button:
                 raise AttributeError(

--- a/pynecone/components/overlay/drawer.py
+++ b/pynecone/components/overlay/drawer.py
@@ -107,7 +107,7 @@ class Drawer(ChakraComponent):
             if props.get("on_close"):
                 # use default close button if undefined
                 if not close_button:
-                    close_button = Icon.create(tag="CloseIcon")
+                    close_button = Icon.create(tag="close")
                 contents.append(DrawerCloseButton.create(close_button))
             elif close_button:
                 raise AttributeError(

--- a/pynecone/components/overlay/modal.py
+++ b/pynecone/components/overlay/modal.py
@@ -105,7 +105,7 @@ class Modal(ChakraComponent):
             if props.get("on_close"):
                 # get user defined close button or use default one
                 if not close_button:
-                    close_button = Icon.create(tag="CloseIcon")
+                    close_button = Icon.create(tag="close")
                 contents.append(ModalCloseButton.create(close_button))
             elif close_button:
                 raise AttributeError(


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### **After** these steps, you're ready to open a pull request.

The PRs that changed usage of the `pc.icon()` broke the multiple Overlay components when they are using `on_close` event trigger.

This PR fix it.

