### PR TITLE
Multiple Page Load Events Added

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -53,7 +53,7 @@ class App(Base):
     middleware: List[Middleware] = []
 
     # Event handlers to trigger when a page loads.
-    load_events: Dict[str, EventHandler] = {}
+    load_events: Dict[str, Union[EventHandler, List[EventHandler]]] = {}
 
     def __init__(self, *args, **kwargs):
         """Initialize the app.
@@ -197,7 +197,7 @@ class App(Base):
         title: str = constants.DEFAULT_TITLE,
         description: str = constants.DEFAULT_DESCRIPTION,
         image=constants.DEFAULT_IMAGE,
-        on_load: Optional[EventHandler] = None,
+        on_load: Optional[Union[EventHandler, List[EventHandler]]] = None,
         path: Optional[str] = None,
         meta: List[Dict] = constants.DEFAULT_META_LIST,
     ):
@@ -213,7 +213,7 @@ class App(Base):
             title: The title of the page.
             description: The description of the page.
             image: The image to display on the page.
-            on_load: The event handler that will be called each time the page load.
+            on_load: The event handler(s) that will be called each time the page load.
             meta: The metadata of the page.
         """
         if path is not None:

--- a/pynecone/route.py
+++ b/pynecone/route.py
@@ -1,6 +1,6 @@
 """The route decorator and associated variables."""
 
-from typing import Optional
+from typing import List, Optional, Union
 
 from pynecone.event import EventHandler
 
@@ -12,7 +12,7 @@ def route(
     title: Optional[str] = None,
     image: Optional[str] = None,
     description: Optional[str] = None,
-    on_load: Optional[EventHandler] = None,
+    on_load: Optional[Union[EventHandler, List[EventHandler]]] = None,
 ):
     """Decorate a function as a page.
 
@@ -28,7 +28,7 @@ def route(
         title: The title of the page.
         image: The favicon of the page.
         description: The description of the page
-        on_load: The event handler called when the page load.
+        on_load: The event handler(s) called when the page load.
 
     Returns:
         The decorated function.


### PR DESCRIPTION
Previously only a single State event handler could be called when loading a page. 

Now either a single event handler or a list of event handlers can be passed. This allows multiple actions to be performed when loading a page which significantly enhances code re-usability in the State classes.


### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?
