### PR TITLE
[Fix: issue 640] Clean up json dumps

### DIFF
--- a/pynecone/components/tags/tag.py
+++ b/pynecone/components/tags/tag.py
@@ -68,7 +68,7 @@ class Tag(Base):
             if not prop.is_local or prop.is_string:
                 return str(prop)
             if issubclass(prop.type_, str):
-                return json.dumps(prop.full_name, ensure_ascii=False)
+                return utils.json_dumps(prop.full_name)
             prop = prop.full_name
 
         # Handle event props.
@@ -88,7 +88,7 @@ class Tag(Base):
         elif isinstance(prop, str):
             if utils.is_wrapped(prop, "{"):
                 return prop
-            return json.dumps(prop, ensure_ascii=False)
+            return utils.json_dumps(prop)
 
         elif isinstance(prop, Figure):
             prop = json.loads(to_json(prop))["data"]  # type: ignore
@@ -103,7 +103,7 @@ class Tag(Base):
                 }
 
             # Dump the prop as JSON.
-            prop = json.dumps(prop, ensure_ascii=False)
+            prop = utils.json_dumps(prop)
 
             # This substitution is necessary to unwrap var values.
             prop = re.sub('"{', "", prop)

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import inspect
-import json
 from typing import Any, Callable, Dict, List, Set, Tuple
 
+from pynecone import utils
 from pynecone.base import Base
 from pynecone.var import BaseVar, Var
 
@@ -67,7 +67,7 @@ class EventHandler(Base):
 
             # Otherwise, convert to JSON.
             try:
-                values.append(json.dumps(arg, ensure_ascii=False))
+                values.append(utils.json_dumps(arg))
             except TypeError as e:
                 raise TypeError(
                     f"Arguments to event handlers must be Vars or JSON-serializable. Got {arg} of type {type(arg)}."

--- a/pynecone/utils.py
+++ b/pynecone/utils.py
@@ -1576,5 +1576,17 @@ def is_backend_variable(name: str) -> bool:
     return name.startswith("_") and not name.startswith("__")
 
 
+def json_dumps(obj: Any):
+    """Serialize ``obj`` to a JSON formatted ``str``, ensure_ascii=False.
+
+    Args:
+        obj: The obj to be fromatted
+
+    Returns:
+        str: The result of the json dumps
+    """
+    return json.dumps(obj, ensure_ascii=False)
+
+
 # Store this here for performance.
 StateBases = get_base_class(StateVar)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,8 +1,6 @@
-import json
-
 import pytest
 
-from pynecone import event
+from pynecone import event, utils
 from pynecone.event import Event, EventHandler, EventSpec
 from pynecone.var import Var
 
@@ -59,8 +57,8 @@ def test_call_event_handler():
     assert event_spec.handler == handler
     assert event_spec.local_args == ()
     assert event_spec.args == (
-        ("arg1", json.dumps(first, ensure_ascii=False)),
-        ("arg2", json.dumps(second, ensure_ascii=False)),
+        ("arg1", utils.json_dumps(first)),
+        ("arg2", utils.json_dumps(second)),
     )
 
     handler = EventHandler(fn=test_fn_with_args)


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Description
Currently we have the line:
`json.dumps(prop, ensure_ascii=False)`
in a lot of places. We should move this to the utils function so we never forget the ensure_ascii flag.

Close #640 
