### PR TITLE
Added parameters to Socket.IO web server

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -89,6 +89,8 @@ class App(Base):
             cors_allowed_origins=cors_allowed_origins,
             cors_credentials=config.cors_credentials,
             max_http_buffer_size=config.polling_max_http_buffer_size,
+            ping_interval=constants.PING_INTERVAL,
+            ping_timeout=constants.PING_TIMEOUT,
         )
 
         # Create the socket app. Note event endpoint constant replaces the default 'socket.io' path.

--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -80,6 +80,9 @@ TIMEOUT = 120
 # The command to run the backend in production mode.
 RUN_BACKEND_PROD = f"gunicorn --worker-class uvicorn.workers.UvicornH11Worker --preload --timeout {TIMEOUT} --log-level critical".split()
 RUN_BACKEND_PROD_WINDOWS = f"uvicorn --timeout-keep-alive {TIMEOUT}".split()
+# Socket.IO web server
+PING_INTERVAL = 25
+PING_TIMEOUT = 5
 
 # Compiler variables.
 # The extension for compiled Javascript files.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?


### Description 

This PR adds two parameters in `pc.constants` to control ping timings of the Socket.IO web server. The name of the two parameters, `PING_INTERVAL` and `PING_TIMETOUT`, are matching the lower case ones from [AsyncServer class](https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class) from `python-socketio`.

Two issues are somewhat related to that PR: https://github.com/pynecone-io/pynecone/issues/258 & https://github.com/pynecone-io/pynecone/issues/424

While both are already closed, I encountered similar difficulties with keeping the connection alive between pinecone app and my android phone (firefox or chrome browser tested), especially when waiting for a long process (40-60s) server side or in situations of low quality network. I found that increasing these two parameters solved my dropped connection issues! In the present commit, the two parameters are instead set to their default values.