### PR TITLE
[fix issue 632] textarea rendering issue

### DIFF
--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -154,7 +154,15 @@ UPLOAD_FN = path_ops.join(
         "}})",
     ]
 ).format
-
+FULL_CONTROL = path_ops.join(
+    [
+        "{{setState(prev => ({{",
+        "...prev,{state_name}: {arg}",
+        "}}), ",
+        "()=>Event([{chain}])",
+        ")}}",
+    ]
+).format
 
 # Effects.
 ROUTER = constants.ROUTER

--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -480,13 +480,13 @@ class Component(Base, ABC):
         return custom_components
 
     def is_full_control(self, kwargs: dict) -> bool:
-        """Return if the component is fully controled input.
+        """Return if the component is fully controlled input.
 
         Args:
             kwargs: The component kwargs.
 
         Returns:
-            Whether fully contoled.
+            Whether fully controlled.
         """
         value = kwargs.get("value")
         if value is None or type(value) != BaseVar:

--- a/pynecone/components/tags/tag.py
+++ b/pynecone/components/tags/tag.py
@@ -78,6 +78,9 @@ class Tag(Base):
             if len(prop.events) == 1 and prop.events[0].upload:
                 # Special case for upload events.
                 event = format.format_upload_event(prop.events[0])
+            elif prop.full_control:
+                # Full control component events.
+                event = format.format_full_control_event(prop)
             else:
                 # All other events.
                 chain = ",".join([format.format_event(event) for event in prop.events])

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -110,6 +110,12 @@ class EventChain(Base):
 
     events: List[EventSpec]
 
+    # Whether events are in fully controlled input.
+    full_control: bool = False
+
+    # State name when fully controlled.
+    state_name: str = ""
+
 
 class Target(Base):
     """A Javascript event target."""

--- a/pynecone/utils/format.py
+++ b/pynecone/utils/format.py
@@ -15,7 +15,7 @@ from pynecone import constants
 from pynecone.utils import types
 
 if TYPE_CHECKING:
-    from pynecone.event import EventHandler, EventSpec
+    from pynecone.event import EventChain, EventHandler, EventSpec
 
 WRAP_MAP = {
     "{": "}",
@@ -301,6 +301,25 @@ def format_upload_event(event_spec: EventSpec) -> str:
     state, name = get_event_handler_parts(event_spec.handler)
     parent_state = state.split(".")[0]
     return f'uploadFiles({parent_state}, {templates.RESULT}, {templates.SET_RESULT}, {parent_state}.files, "{state}.{name}",UPLOAD)'
+
+
+def format_full_control_event(event_chain: EventChain) -> str:
+    """Format an fully controlled input prop.
+
+    Args:
+        event_chain: The event chain for full controlled input.
+
+    Returns:
+        The compiled event.
+    """
+    from pynecone.compiler import templates
+
+    event_spec = event_chain.events[0]
+    arg = event_spec.args[0][1]
+    state_name = event_chain.state_name
+    chain = ",".join([format_event(event) for event in event_chain.events])
+    event = templates.FULL_CONTROL(state_name=state_name, arg=arg, chain=chain)
+    return event
 
 
 def format_query_params(router_data: Dict[str, Any]) -> Dict[str, str]:

--- a/pynecone/utils/format.py
+++ b/pynecone/utils/format.py
@@ -304,7 +304,7 @@ def format_upload_event(event_spec: EventSpec) -> str:
 
 
 def format_full_control_event(event_chain: EventChain) -> str:
-    """Format an fully controlled input prop.
+    """Format a fully controlled input prop.
 
     Args:
         event_chain: The event chain for full controlled input.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Description
In order to controll textarea, we need to synchronize the state.
However, event chain executed asynchronizing. 
So, I synchronize state before event chain.

#### Usage
no need to change py file.
```py
pc.text_area(
    value=State.area_value, 
    on_change=State.set_area_value,
)
```

The js file is changed below.

```js

// before
onChange={(_e) => Event([...chain])}

// after
onChange={(_e)=>{setState(prev =>{
  ... // set state sync
  }), 
  () => Event([...chain]) // event after set state
)}}
```