### PR TITLE
Pynecone App should prevent all pycache folders and all .pyc, .pyo, .pyd files from being uploaded.

### DIFF
--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -136,7 +136,7 @@ DEFAULT_META_LIST = []
 # The gitignore file.
 GITIGNORE_FILE = ".gitignore"
 # Files to gitignore.
-DEFAULT_GITIGNORE = {WEB_DIR, DB_NAME}
+DEFAULT_GITIGNORE = {WEB_DIR, DB_NAME, "__pycache__/", "*.py[cod]"}
 # The name of the pynecone config module.
 CONFIG_MODULE = "pcconfig"
 # The python config file.


### PR DESCRIPTION
Pynecone. App should prevent all pycache folders and all .pyc, .pyo, .pyd files from being uploaded.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).



`pc init` will create the .gitignore  file that cannot prevent `__pycache__` upload to the git. 
And python application developer need this function. 
