### PR TITLE
[Feature: #734] Add custom init name

### DIFF
--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -23,9 +23,9 @@ def version():
 
 
 @cli.command()
-def init():
+def init(name: str = typer.Option(None, help="Name of the app to be initialized.")):
     """Initialize a new Pynecone app in the current directory."""
-    app_name = prerequisites.get_default_app_name()
+    app_name = prerequisites.get_default_app_name() if name is None else name
 
     # Make sure they don't name the app "pynecone".
     if app_name == constants.MODULE_NAME:


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?


### Description

Add feature to give a custom name to your app when doing ```pc init```.
This can be done by giving the ```--name``` flag followed by the name of your app to ```pc init```.
For example:
If you want your app to be named "myapp", you would do ```pc init --name myapp```.
![image](https://user-images.githubusercontent.com/83450142/228011515-84986c40-b82f-4e1c-8a58-994391165b1a.png)
Again, this is just optional. You can also just do ```pc init``` which will by default take the name of the current directory as your app's name.
closes #734 