### PR TITLE
Use Strict (In)Equality in Generated Javascript

### DIFF
--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -373,7 +373,7 @@ class Var(ABC):
         Returns:
             A var representing the equality comparison.
         """
-        return self.compare("==", other)
+        return self.compare("===", other)
 
     def __ne__(self, other: Var) -> Var:
         """Perform an inequality comparison.
@@ -384,7 +384,7 @@ class Var(ABC):
         Returns:
             A var representing the inequality comparison.
         """
-        return self.compare("!=", other)
+        return self.compare("!==", other)
 
     def __gt__(self, other: Var) -> Var:
         """Perform a greater than comparison.


### PR DESCRIPTION
Use strict equality and inequality in generated javascript equality checks.  

**Reason**: Javascript's strict equality semantically more similar to Python's notion of equality than the previously used equality. This difference mainly stems from Javascript's heavy reliance on type coercion when evaluating the equality operator. The strict equality operator avoids this type coercion.

Some examples showing why this is a good change:
```javascript
// Javascript equality:
2 == "2"; // true
"1,2" == [1, 2]; // true
```
```python
# Python equality:
2 == "2" # False
"1,2" == [1, 2]  # False
```

```javascript
// Javascript strict equality:
2 === "2"; // false
"1,2" === [1, 2]; // false
```

The one drawback to this change is that the following correct (read: same as Python) behavior will disappear:
```javascript
1 == true; // true
0 == false // true
``` 
But I believe that this is a rather uncommon expression. This change will not affect the behavior of `pc.cond(State.some_integer, ...)`. The change only affects this exact equality operation, with these exact operands.

Sources:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality https://tc39.es/ecma262/#sec-isstrictlyequal
https://docs.python.org/3/reference/expressions.html

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
