### PR TITLE
Fix crash when NaN, Inf or -Inf in frontend state.

### DIFF
--- a/pynecone/.templates/web/package.json
+++ b/pynecone/.templates/web/package.json
@@ -32,6 +32,7 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "socket.io-client": "^4.5.4",
-    "victory": "^36.6.8"
+    "victory": "^36.6.8",
+    "json5": "^2.2.3"
   }
 }

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -1,6 +1,7 @@
 // State management for Pynecone web apps.
 import axios from "axios";
 import io from "socket.io-client";
+import JSON5 from "json5";
 
 // Global variable to hold the token.
 let token;
@@ -175,7 +176,7 @@ export const connect = async (
 
   // On each received message, apply the delta and set the result.
   socket.current.on("event", function (update) {
-    update = JSON.parse(update);
+    update = JSON5.parse(update);
     applyDelta(state, update.delta);
     setResult({
       processing: true,


### PR DESCRIPTION
## Problem
Currently, any occurrence of `NaN`, `Infinity` or `-Infinity` inside the react state will cause the frontend to error after rendering. This happens because these values are not valid JSON, which means that the call to JSON.parse() in the socket's event handler throws an Error that is not handled. 

This is unfortunate, is these values are not uncommon in various statistics and other science-related code. 

### Example
```python
data = pd.DataFrame({
    "name": ["jane", "rob", "harry"],
    "age": [3, 2, 0],
    "height_cm": [90, 80, 50],
})
data["annual_growth_cm"] = data["height_cm"] / data["age"]  # Division by 0 => Infinity

class State(pc.State):
    data = data

def index() -> pc.Component:
    return pc.vstack(
        pc.data_table(data=State.data)
    )
```

results in this error on the frontend:
![image](https://user-images.githubusercontent.com/32123499/228531538-d764e5ed-b9ab-4393-aa7f-a1e20d235479.png)

Though reproducing the error is really just as simple as doing this:
```python
import math

class State(pc.State):
    nan= math.nan

def index() -> pc.Component:
    return pc.text("")

app = pc.App(state=State)
```


## Solution
Parse the JSON using the `json5` [library](https://github.com/json5/json5) instead of using the native json parser. This requires the package to be installed, imported into  `state.js` and used to parse state update. 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

