### PR TITLE
Fix Event chaining in the on_load event handler return not working

### DIFF
--- a/pynecone/components/typography/markdown.py
+++ b/pynecone/components/typography/markdown.py
@@ -69,7 +69,7 @@ class Markdown(Component):
                     "li": "{ListItem}",
                     "p": "{Text}",
                     "a": "{Link}",
-                    "code": """{({node, inline, className, children, ...props}) => 
+                    "code": """{({node, inline, className, children, ...props}) =>
                     {
         const match = (className || '').match(/language-(?<lang>.*)/);
         return !inline ? (

--- a/pynecone/middleware/hydrate_middleware.py
+++ b/pynecone/middleware/hydrate_middleware.py
@@ -1,12 +1,12 @@
 """Middleware to hydrate the state."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from pynecone import constants
 from pynecone.event import Event, EventHandler, get_hydrate_event
 from pynecone.middleware.middleware import Middleware
-from pynecone.state import Delta, State
+from pynecone.state import Delta, State, StateUpdate
 from pynecone.utils import format
 
 if TYPE_CHECKING:
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
 class HydrateMiddleware(Middleware):
     """Middleware to handle initial app hydration."""
 
-    def preprocess(self, app: App, state: State, event: Event) -> Optional[Delta]:
+    async def preprocess(
+        self, app: App, state: State, event: Event
+    ) -> Union[Optional[Delta], List[StateUpdate]]:
         """Preprocess the event.
 
         Args:
@@ -25,7 +27,7 @@ class HydrateMiddleware(Middleware):
             event: The event to preprocess.
 
         Returns:
-            An optional state to return.
+            An optional delta or list of state updates to return.
         """
         if event.name == get_hydrate_event(state):
             route = event.router_data.get(constants.RouteVar.PATH, "")
@@ -37,20 +39,42 @@ class HydrateMiddleware(Middleware):
                 load_event = None
 
             if load_event:
-                if isinstance(load_event, list):
-                    for single_event in load_event:
-                        self.execute_load_event(state, single_event)
-                else:
-                    self.execute_load_event(state, load_event)
+                if not isinstance(load_event, List):
+                    load_event = [load_event]
+                updates = []
+                for single_event in load_event:
+                    updates.append(
+                        await self.execute_load_event(
+                            state, single_event, event.token, event.payload
+                        )
+                    )
+                return updates
             return format.format_state({state.get_name(): state.dict()})
 
-    def execute_load_event(self, state: State, load_event: EventHandler) -> None:
+    async def execute_load_event(
+        self, state: State, load_event: EventHandler, token: str, payload: Dict
+    ) -> StateUpdate:
         """Execute single load event.
 
         Args:
             state: The client state.
             load_event: A single load event to execute.
+            token: client token
+            payload: the event payload
+
+        Returns:
+            A state Update.
+
+        Raises:
+            ValueError: If the state value is None.
         """
         substate_path = format.format_event_handler(load_event).split(".")
         ex_state = state.get_substate(substate_path[:-1])
-        load_event.fn(ex_state)
+        if ex_state:
+            return await state.process_event(
+                handler=load_event, state=ex_state, payload=payload, token=token
+            )
+        else:
+            raise ValueError(
+                "The value of state cannot be None when processing an on-load event."
+            )

--- a/pynecone/middleware/logging_middleware.py
+++ b/pynecone/middleware/logging_middleware.py
@@ -24,7 +24,7 @@ class LoggingMiddleware(Middleware):
         """
         print(f"Event {event}")
 
-    def postprocess(self, app: App, state: State, event: Event, delta: Delta):
+    async def postprocess(self, app: App, state: State, event: Event, delta: Delta):
         """Postprocess the event.
 
         Args:

--- a/pynecone/middleware/logging_middleware.py
+++ b/pynecone/middleware/logging_middleware.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class LoggingMiddleware(Middleware):
     """Middleware to log requests and responses."""
 
-    def preprocess(self, app: App, state: State, event: Event):
+    async def preprocess(self, app: App, state: State, event: Event):
         """Preprocess the event.
 
         Args:

--- a/pynecone/middleware/middleware.py
+++ b/pynecone/middleware/middleware.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class Middleware(Base, ABC):
     """Middleware to preprocess and postprocess requests."""
 
-    def preprocess(self, app: App, state: State, event: Event) -> Optional[Delta]:
+    async def preprocess(self, app: App, state: State, event: Event) -> Optional[Delta]:
         """Preprocess the event.
 
         Args:

--- a/pynecone/middleware/middleware.py
+++ b/pynecone/middleware/middleware.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from pynecone.base import Base
 from pynecone.event import Event
-from pynecone.state import Delta, State
+from pynecone.state import Delta, State, StateUpdate
 
 if TYPE_CHECKING:
     from pynecone.app import App
@@ -15,7 +15,9 @@ if TYPE_CHECKING:
 class Middleware(Base, ABC):
     """Middleware to preprocess and postprocess requests."""
 
-    async def preprocess(self, app: App, state: State, event: Event) -> Optional[Delta]:
+    async def preprocess(
+        self, app: App, state: State, event: Event
+    ) -> Optional[Union[StateUpdate, List[StateUpdate]]]:
         """Preprocess the event.
 
         Args:
@@ -28,7 +30,7 @@ class Middleware(Base, ABC):
         """
         return None
 
-    def postprocess(
+    async def postprocess(
         self, app: App, state: State, event: Event, delta
     ) -> Optional[Delta]:
         """Postprocess the event.

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -203,12 +203,12 @@ def export(
 
     if zipping:
         console.rule(
-            """Backend & Frontend compiled. See [green bold]backend.zip[/green bold] 
+            """Backend & Frontend compiled. See [green bold]backend.zip[/green bold]
             and [green bold]frontend.zip[/green bold]."""
         )
     else:
         console.rule(
-            """Backend & Frontend compiled. See [green bold]app[/green bold] 
+            """Backend & Frontend compiled. See [green bold]app[/green bold]
             and [green bold].web/_static[/green bold] directories."""
         )
 

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -546,13 +546,16 @@ class State(Base, ABC):
         return self.substates[path[0]].get_substate(path[1:])
 
     async def process(self, event: Event) -> StateUpdate:
-        """Process an event.
+        """Obtain event info and process event.
 
         Args:
             event: The event to process.
 
         Returns:
             The state update after processing the event.
+
+        Raises:
+            ValueError: If the state value is None.
         """
         # Get the event handler.
         path = event.name.split(".")
@@ -560,23 +563,48 @@ class State(Base, ABC):
         substate = self.get_substate(path)
         handler = substate.event_handlers[name]  # type: ignore
 
-        # Process the event.
-        fn = functools.partial(handler.fn, substate)
+        if substate:
+            return await self.process_event(
+                handler=handler,
+                state=substate,
+                payload=event.payload,
+                token=event.token,
+            )
+        else:
+            raise ValueError(
+                "The value of state cannot be None when processing an event."
+            )
+
+    async def process_event(
+        self, handler: EventHandler, state: State, payload: Dict, token: str
+    ) -> StateUpdate:
+        """Process event.
+
+        Args:
+            handler: Eventhandler to process.
+            state: state to process the handler.
+            payload: the event payload.
+            token: client token.
+
+        Returns:
+            The state update after processing the event.
+        """
+        fn = functools.partial(handler.fn, state)
         try:
             if asyncio.iscoroutinefunction(fn.func):
-                events = await fn(**event.payload)
+                events = await fn(**payload)
             else:
-                events = fn(**event.payload)
+                events = fn(**payload)
         except Exception:
             error = traceback.format_exc()
             print(error)
             events = fix_events(
-                [window_alert("An error occurred. See logs for details.")], event.token
+                [window_alert("An error occurred. See logs for details.")], token
             )
             return StateUpdate(events=events)
 
         # Fix the returned events.
-        events = fix_events(events, event.token)
+        events = fix_events(events, token)
 
         # Get the delta after processing the event.
         delta = self.get_delta()

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -563,17 +563,17 @@ class State(Base, ABC):
         substate = self.get_substate(path)
         handler = substate.event_handlers[name]  # type: ignore
 
-        if substate:
-            return await self.process_event(
-                handler=handler,
-                state=substate,
-                payload=event.payload,
-                token=event.token,
-            )
-        else:
+        if not substate:
             raise ValueError(
                 "The value of state cannot be None when processing an event."
             )
+
+        return await self.process_event(
+            handler=handler,
+            state=substate,
+            payload=event.payload,
+            token=event.token,
+        )
 
     async def process_event(
         self, handler: EventHandler, state: State, payload: Dict, token: str
@@ -582,9 +582,9 @@ class State(Base, ABC):
 
         Args:
             handler: Eventhandler to process.
-            state: state to process the handler.
-            payload: the event payload.
-            token: client token.
+            state: State to process the handler.
+            payload: The event payload.
+            token: Client token.
 
         Returns:
             The state update after processing the event.

--- a/tests/components/datadisplay/test_datatable.py
+++ b/tests/components/datadisplay/test_datatable.py
@@ -94,7 +94,6 @@ def test_computed_var_without_annotation(fixture, request, err_msg, is_data_fram
         is_data_frame: whether data field is a pandas dataframe.
     """
     with pytest.raises(ValueError) as err:
-
         if is_data_frame:
             data_table(data=request.getfixturevalue(fixture).data)
         else:

--- a/tests/middleware/conftest.py
+++ b/tests/middleware/conftest.py
@@ -27,3 +27,8 @@ def event1():
 @pytest.fixture
 def event2():
     return create_event("test_state2.hydrate")
+
+
+@pytest.fixture
+def event3():
+    return create_event("test_state3.hydrate")

--- a/tests/middleware/conftest.py
+++ b/tests/middleware/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pynecone.event import Event
+
+
+def create_event(name):
+    return Event(
+        token="<token>",
+        name=name,
+        router_data={
+            "pathname": "/",
+            "query": {},
+            "token": "<token>",
+            "sid": "<sid>",
+            "headers": {},
+            "ip": "127.0.0.1",
+        },
+        payload={},
+    )
+
+
+@pytest.fixture
+def event1():
+    return create_event("test_state.hydrate")
+
+
+@pytest.fixture
+def event2():
+    return create_event("test_state2.hydrate")

--- a/tests/middleware/test_hydrate_middleware.py
+++ b/tests/middleware/test_hydrate_middleware.py
@@ -37,12 +37,23 @@ class TestState2(State):
         self.name = "random"
 
 
+class TestState3(State):
+    """A test state with async handler."""
+
+    num: int = 0
+
+    async def test_handler(self):
+        """Test handler."""
+        self.num += 1
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "state, expected, event_fixture",
     [
         (TestState, {"test_state": {"num": 1}}, "event1"),
         (TestState2, {"test_state2": {"num": 1}}, "event2"),
+        (TestState3, {"test_state3": {"num": 1}}, "event3"),
     ],
 )
 async def test_preprocess(state, request, event_fixture, expected):

--- a/tests/middleware/test_hydrate_middleware.py
+++ b/tests/middleware/test_hydrate_middleware.py
@@ -1,0 +1,85 @@
+from typing import List
+
+import pytest
+
+from pynecone.app import App
+from pynecone.middleware.hydrate_middleware import HydrateMiddleware
+from pynecone.state import State
+
+
+class TestState(State):
+    """A test state with no return in handler."""
+
+    num: int = 0
+
+    def test_handler(self):
+        """Test handler."""
+        self.num += 1
+
+
+class TestState2(State):
+    """A test state with return in handler."""
+
+    num: int = 0
+    name: str
+
+    def test_handler(self):
+        """Test handler that calls another handler.
+
+        Returns:
+            Chain of EventHandlers
+        """
+        self.num += 1
+        return [self.change_name()]
+
+    def change_name(self):
+        """Test handler to change name."""
+        self.name = "random"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state, expected, event_fixture",
+    [
+        (TestState, {"test_state": {"num": 1}}, "event1"),
+        (TestState2, {"test_state2": {"num": 1}}, "event2"),
+    ],
+)
+async def test_preprocess(state, request, event_fixture, expected):
+    """Test that a state hydrate event is processed correctly.
+
+    Args:
+        state: state to process event
+        request: pytest fixture request
+        event_fixture: The event fixture(an Event)
+        expected: expected delta
+    """
+    app = App(state=state, load_events={"index": state.test_handler})
+
+    hydrate_middleware = HydrateMiddleware()
+    result = await hydrate_middleware.preprocess(
+        app=app, event=request.getfixturevalue(event_fixture), state=state()
+    )
+    assert isinstance(result, List)
+    assert result[0].delta == expected
+
+
+@pytest.mark.asyncio
+async def test_preprocess_multiple_load_events(event1):
+    """Test that a state hydrate event for multiple on-load events is processed correctly.
+
+    Args:
+        event1: an Event.
+    """
+    app = App(
+        state=TestState,
+        load_events={"index": [TestState.test_handler, TestState.test_handler]},
+    )
+
+    hydrate_middleware = HydrateMiddleware()
+    result = await hydrate_middleware.preprocess(
+        app=app, event=event1, state=TestState()
+    )
+    assert isinstance(result, List)
+    assert result[0].delta == {"test_state": {"num": 1}}
+    assert result[1].delta == {"test_state": {"num": 2}}


### PR DESCRIPTION
This PR fixes a couple of issues with the way on-load events are handled. In this PR, the following should work now:

- event-chaining( handlers that return other handlers)
- list of on-load events (eg. `app.add_page('index', on_load = [State.first_handler, State.second_handler]`)
- Async handlers

fixes #610 , #603
