### PR TITLE
Fix --xxxend-only and only kill its related port

### DIFF
--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -61,15 +61,18 @@ def run(
         constants.Env.DEV, help="The environment to run the app in."
     ),
     frontend: bool = typer.Option(
-        True, "--no-frontend", help="Disable frontend execution."
+        False, "--frontend-only", help="Enable execution only frontend."
     ),
     backend: bool = typer.Option(
-        True, "--no-backend", help="Disable backend execution."
+        False, "--backend-only", help="Enable execution only backend."
     ),
     loglevel: constants.LogLevel = typer.Option(
         constants.LogLevel.ERROR, help="The log level to use."
     ),
-    port: str = typer.Option(None, help="Specify a different port."),
+    port: str = typer.Option(None, help="Specify a different frontend port."),
+    backend_port: str = typer.Option(
+        None, "--backend-port", help="Specify a different backend port."
+    ),
 ):
     """Run the app in the current directory."""
     if platform.system() == "Windows":
@@ -78,13 +81,13 @@ def run(
         )
 
     frontend_port = get_config().port if port is None else port
-    backend_port = get_config().backend_port
+    backend_port = get_config().backend_port if backend_port is None else backend_port
 
     # If something is running on the ports, ask the user if they want to kill or change it.
-    if processes.is_process_on_port(frontend_port):
+    if frontend and processes.is_process_on_port(frontend_port):
         frontend_port = processes.change_or_terminate_port(frontend_port, "frontend")
 
-    if processes.is_process_on_port(backend_port):
+    if backend and processes.is_process_on_port(backend_port):
         backend_port = processes.change_or_terminate_port(backend_port, "backend")
 
     # Check that the app is initialized.
@@ -123,8 +126,10 @@ def run(
         if backend:
             backend_cmd(app.__name__, port=int(backend_port), loglevel=loglevel)
     finally:
-        processes.kill_process_on_port(frontend_port)
-        processes.kill_process_on_port(backend_port)
+        if frontend:
+            processes.kill_process_on_port(frontend_port)
+        if backend:
+            processes.kill_process_on_port(backend_port)
 
 
 @cli.command()


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### New Feature Submission:

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.
This PR is to fix issue https://github.com/pynecone-io/pynecone/issues/786 and improve something too.
The original code will kill two ports even using --no-backend or --no-frontend. 
I changed --no-backend into --frontend-only and fixed the issue I found out above. 
In the source code, we know --port is means frontend port, but people may misunderstand here. 
So I add --backend-port. When people type `pc run --help`, they will get the following information. 
```
Usage: pc run [OPTIONS]

  Run the app in the current directory.

Options:
  --env [dev|prod]                The environment to run the app in.
                                  [default: Env.DEV]
  --frontend-only                 Enable execution only frontend.
  --backend-only                  Enable execution only backend.
  --loglevel [debug|info|warning|error|critical]
                                  The log level to use.  [default:
                                  LogLevel.ERROR]
  --port TEXT                     Specify a different frontend port.
  --backend-port TEXT             Specify a different backend port.
  --help                          Show this message and exit.
```
It makes developers understand quickly without misunderstanding. 
In the future, I suggest we can add ` --api-url` too. It could make the `pc run` command more friendly to the web app developer. 


    b. Describe your changes.
1. --no-backend -> --frontend-only
2. --no-frontend -> --backend-only
3. only ask to kill frontend port when using --frontend-only and the port conflict
4. only ask to kill backend port when using --backend-only and the port conflict

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
closes #786 
