### PR TITLE
Initialize an EventHandler for dynamic vars

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -180,7 +180,9 @@ class State(Base, ABC):
         events = {
             name: fn
             for name, fn in cls.__dict__.items()
-            if not name.startswith("_") and isinstance(fn, Callable)
+            if not name.startswith("_")
+            and isinstance(fn, Callable)
+            and not isinstance(fn, EventHandler)
         }
         for name, fn in events.items():
             event_handler = EventHandler(fn=fn)
@@ -369,7 +371,9 @@ class State(Base, ABC):
         """
         setter_name = prop.get_setter_name(include_state=False)
         if setter_name not in cls.__dict__:
-            setattr(cls, setter_name, prop.get_setter())
+            event_handler = EventHandler(fn=prop.get_setter())
+            cls.event_handlers[setter_name] = event_handler
+            setattr(cls, setter_name, event_handler)
 
     @classmethod
     def _set_default_value(cls, prop: BaseVar):


### PR DESCRIPTION
### Summary

When constructing a class dynamically using `add_var`, the auto generated `set_XXX` method is not an `EventHandler` so pc complains:
```
ValueError: Lambda <function app_state.add.set_a at 0x7fb248e5f520> must have 0 or 1 arguments.
```

This changes the `_create_setter` method to wrap the prop setter in an `EventHandler` and also adds a check in the `__init__subclass__` to prevent double wrapping of the `EventHandler`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?


