### PR TITLE
File upload to use single syntax:

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -489,31 +489,26 @@ def upload(app: App):
         # get handler function
         func = getattr(state, handler.split(".")[-1])
 
-        # check if there exists any handler args with annotation UploadFile or List[UploadFile]
+        # check if there exists any handler args with annotation, List[UploadFile]
         for k, v in inspect.getfullargspec(
             func.fn if isinstance(func, EventHandler) else func
         ).annotations.items():
-            if (
-                types.is_generic_alias(v)
-                and types._issubclass(v.__args__[0], UploadFile)
-                or types._issubclass(v, UploadFile)
+            if types.is_generic_alias(v) and types._issubclass(
+                v.__args__[0], UploadFile
             ):
                 handler_upload_param = (k, v)
                 break
 
         if not handler_upload_param:
             raise ValueError(
-                f"`{handler}` handler should have a parameter annotated with one of the following: List["
-                f"pc.UploadFile], pc.UploadFile "
+                f"`{handler}` handler should have a parameter annotated as List["
+                f"pc.UploadFile]"
             )
-
-        # check if handler supports multi-upload
-        multi_upload = types._issubclass(handler_upload_param[1], List)
 
         event = Event(
             token=token,
             name=handler,
-            payload={handler_upload_param[0]: files if multi_upload else files[0]},
+            payload={handler_upload_param[0]: files},
         )
         update = await state.process(event)
         return update

--- a/pynecone/components/typography/markdown.py
+++ b/pynecone/components/typography/markdown.py
@@ -69,7 +69,7 @@ class Markdown(Component):
                     "li": "{ListItem}",
                     "p": "{Text}",
                     "a": "{Link}",
-                    "code": """{({node, inline, className, children, ...props}) => 
+                    "code": """{({node, inline, className, children, ...props}) =>
                     {
         const match = (className || '').match(/language-(?<lang>.*)/);
         return !inline ? (

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -203,12 +203,12 @@ def export(
 
     if zipping:
         console.rule(
-            """Backend & Frontend compiled. See [green bold]backend.zip[/green bold] 
+            """Backend & Frontend compiled. See [green bold]backend.zip[/green bold]
             and [green bold]frontend.zip[/green bold]."""
         )
     else:
         console.rule(
-            """Backend & Frontend compiled. See [green bold]app[/green bold] 
+            """Backend & Frontend compiled. See [green bold]app[/green bold]
             and [green bold].web/_static[/green bold] directories."""
         )
 

--- a/tests/components/datadisplay/test_datatable.py
+++ b/tests/components/datadisplay/test_datatable.py
@@ -94,7 +94,6 @@ def test_computed_var_without_annotation(fixture, request, err_msg, is_data_fram
         is_data_frame: whether data field is a pandas dataframe.
     """
     with pytest.raises(ValueError) as err:
-
         if is_data_frame:
             data_table(data=request.getfixturevalue(fixture).data)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,18 +141,7 @@ def dict_mutation_state():
 class UploadState(pc.State):
     """The base state for uploading a file."""
 
-    img: str
-    img_list: List[str]
-
-    async def handle_upload1(self, file: pc.UploadFile):
-        """Handle the upload of a file.
-
-        Args:
-            file: The uploaded file.
-        """
-        pass
-
-    async def multi_handle_upload(self, files: List[pc.UploadFile]):
+    async def handle_upload1(self, files: List[pc.UploadFile]):
         """Handle the upload of a file.
 
         Args:
@@ -172,23 +161,13 @@ class SubUploadState(BaseState):
 
     img: str
 
-    async def handle_upload(self, file: pc.UploadFile):
+    async def handle_upload(self, files: List[pc.UploadFile]):
         """Handle the upload of a file.
 
         Args:
-            file: The uploaded file.
+            files: The uploaded files.
         """
         pass
-
-
-@pytest.fixture
-def upload_event_spec():
-    """Create an event Spec for a base state.
-
-    Returns:
-        Event Spec.
-    """
-    return EventSpec(handler=UploadState.handle_upload1, upload=True)  # type: ignore
 
 
 @pytest.fixture
@@ -202,13 +181,13 @@ def upload_sub_state_event_spec():
 
 
 @pytest.fixture
-def multi_upload_event_spec():
+def upload_event_spec():
     """Create an event Spec for a multi-upload base state.
 
     Returns:
         Event Spec.
     """
-    return EventSpec(handler=UploadState.multi_handle_upload, upload=True)  # type: ignore
+    return EventSpec(handler=UploadState.handle_upload1, upload=True)  # type: ignore
 
 
 @pytest.fixture
@@ -226,24 +205,24 @@ def upload_state(tmp_path):
     class FileUploadState(pc.State):
         """The base state for uploading a file."""
 
-        img: str
         img_list: List[str]
 
-        async def handle_upload2(self, file):
+        async def handle_upload2(self, files):
             """Handle the upload of a file.
 
             Args:
-                file: The uploaded file.
+                files: The uploaded files.
             """
-            upload_data = await file.read()
-            outfile = f"{tmp_path}/{file.filename}"
+            for file in files:
+                upload_data = await file.read()
+                outfile = f"{tmp_path}/{file.filename}"
 
-            # Save the file.
-            with open(outfile, "wb") as file_object:
-                file_object.write(upload_data)
+                # Save the file.
+                with open(outfile, "wb") as file_object:
+                    file_object.write(upload_data)
 
-            # Update the img var.
-            self.img = file.filename
+                # Update the img var.
+                self.img_list.append(file.filename)
 
         async def multi_handle_upload(self, files: List[pc.UploadFile]):
             """Handle the upload of a file.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -474,6 +474,5 @@ async def test_upload_file_without_annotation(upload_state):
         await fn([file1, file2])
     assert (
         err.value.args[0]
-        == "`upload_state.handle_upload2` handler should have a parameter annotated with one of the following: "
-        "List[pc.UploadFile], pc.UploadFile "
+        == "`upload_state.handle_upload2` handler should have a parameter annotated as List[pc.UploadFile]"
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -287,20 +287,6 @@ def test_issubclass(cls: type, cls_check: type, expected: bool):
     assert types._issubclass(cls, cls_check) == expected
 
 
-def test_format_upload_event(upload_event_spec):
-    """Test formatting an upload event spec.
-
-    Args:
-        upload_event_spec: The event spec fixture.
-    """
-    assert (
-        format.format_upload_event(upload_event_spec)
-        == "uploadFiles(upload_state, result, setResult, "
-        'upload_state.files, "upload_state.handle_upload1",'
-        "UPLOAD)"
-    )
-
-
 def test_format_sub_state_event(upload_sub_state_event_spec):
     """Test formatting an upload event spec of substate.
 
@@ -314,15 +300,15 @@ def test_format_sub_state_event(upload_sub_state_event_spec):
     )
 
 
-def test_format_multi_upload_event(multi_upload_event_spec):
+def test_format_upload_event(upload_event_spec):
     """Test formatting an upload event spec.
 
     Args:
-        multi_upload_event_spec: The event spec fixture.
+        upload_event_spec: The event spec fixture.
     """
     assert (
-        format.format_upload_event(multi_upload_event_spec)
+        format.format_upload_event(upload_event_spec)
         == "uploadFiles(upload_state, result, setResult, "
-        'upload_state.files, "upload_state.multi_handle_upload",'
+        'upload_state.files, "upload_state.handle_upload1",'
         "UPLOAD)"
     )


### PR DESCRIPTION
Refactored file upload feature to use only lists for Python syntax. If you want a single upload, set the multiple prop to False

eg:
```python
import pynecone as pc
from typing import List

class State(pc.State):
    """The base state."""
    # The images to show.
    img: list[str] = []

    async def handle_upload(self, files: List[pc.UploadFile]):
        """Handle the upload of files.

        Args:
            files: The uploaded file.
        """
        for file in files:
            upload_data = await file.read()
            outfile = f".web/public/{file.filename}"

            # Save the file.
            with open(outfile, "wb") as file_object:
                file_object.write(upload_data)

            # Update the img var.
            self.img.append(file.filename)


def index():
    """The main view."""
    return pc.vstack(

        pc.upload(
            pc.button("Select File"),
            pc.text("Drag and drop files here or click to select files"),
            border="1px dotted black",
            padding="20em",
            multiple=False
        ),
        pc.button(
            "Upload",
            on_click=lambda: State.handle_upload(pc.upload_files())
        ),
        pc.foreach(State.img, lambda img: pc.image(src=img)),
    )


# Add state and page to the app.
app = pc.App(state=State)
app.add_page(index, title="Upload")
app.compile()

```

fixes #774 