### PR TITLE
Python 3.10 tag issubclass bug

### DIFF
--- a/pynecone/components/tags/tag.py
+++ b/pynecone/components/tags/tag.py
@@ -67,7 +67,7 @@ class Tag(Base):
         if isinstance(prop, Var):
             if not prop.is_local or prop.is_string:
                 return str(prop)
-            if issubclass(prop.type_, str):
+            if types._issubclass(prop.type_, str):
                 return format.json_dumps(prop.full_name)
             prop = prop.full_name
 

--- a/tests/components/test_tag.py
+++ b/tests/components/test_tag.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
 
@@ -41,6 +41,16 @@ def mock_event(arg):
         ),
         ({"a": "red", "b": "blue"}, '{{"a": "red", "b": "blue"}}'),
         (BaseVar(name="var", type_="int"), "{var}"),
+        (
+            BaseVar(
+                name="_",
+                type_=Any,
+                state="",
+                is_local=True,
+                is_string=False,
+            ),
+            "{_}",
+        ),
         (BaseVar(name='state.colors["a"]', type_="str"), '{state.colors["a"]}'),
         ({"a": BaseVar(name="val", type_="str")}, '{{"a": val}}'),
         ({"a": BaseVar(name='"val"', type_="str")}, '{{"a": "val"}}'),


### PR DESCRIPTION
This PR fixes the issubclass error:
`TypeError: issubclass() arg 1 must be a class` when formatting a prop in tag.py


fixes #821 