### PR TITLE
Apply convert_handlers_to_fns for substates

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -194,6 +194,9 @@ class State(Base, ABC):
         """
         for name, event_handler in cls.event_handlers.items():
             setattr(cls, name, event_handler.fn)
+        for substate in cls.get_substates():
+            substate.convert_handlers_to_fns()
+
 
     @classmethod
     def set_handlers(cls):

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -197,7 +197,6 @@ class State(Base, ABC):
         for substate in cls.get_substates():
             substate.convert_handlers_to_fns()
 
-
     @classmethod
     def set_handlers(cls):
         """Set the state class handlers."""


### PR DESCRIPTION
Previously, functions of substates could not be called as normal functions during runtime.  

This bug fix recursively registers each substate's event handler function as an attribute so that it can be called as a normal function during runtime.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
