### PR TITLE
Modify some methods in state.py to prevent being overwritten 

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -455,7 +455,7 @@ async def process(
 
     # Apply the event to the state.
     if updates is None:
-        updates = [await state.process(event)]
+        updates = [await state._process(event)]
         app.state_manager.set_state(event.token, state)
 
     # Postprocess the event.
@@ -534,7 +534,7 @@ def upload(app: App):
             name=handler,
             payload={handler_upload_param[0]: files},
         )
-        update = await state.process(event)
+        update = await state._process(event)
         return update
 
     return upload_file

--- a/pynecone/middleware/hydrate_middleware.py
+++ b/pynecone/middleware/hydrate_middleware.py
@@ -76,6 +76,6 @@ class HydrateMiddleware(Middleware):
                 "The value of state cannot be None when processing an on-load event."
             )
 
-        return await state.process_event(
+        return await state._process_event(
             handler=load_event, state=ex_state, payload=payload, token=token
         )

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -552,7 +552,7 @@ class State(Base, ABC):
             raise ValueError(f"Invalid path: {path}")
         return self.substates[path[0]].get_substate(path[1:])
 
-    async def process(self, event: Event) -> StateUpdate:
+    async def _process(self, event: Event) -> StateUpdate:
         """Obtain event info and process event.
 
         Args:
@@ -575,14 +575,14 @@ class State(Base, ABC):
                 "The value of state cannot be None when processing an event."
             )
 
-        return await self.process_event(
+        return await self._process_event(
             handler=handler,
             state=substate,
             payload=event.payload,
             token=event.token,
         )
 
-    async def process_event(
+    async def _process_event(
         self, handler: EventHandler, state: State, payload: Dict, token: str
     ) -> StateUpdate:
         """Process event.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -272,7 +272,7 @@ async def test_list_mutation_detection__plain_list(
         list_mutation_state: A state with list mutation features.
     """
     for event_name, expected_delta in event_tuples:
-        result = await list_mutation_state.process(
+        result = await list_mutation_state._process(
             Event(
                 token="fake-token",
                 name=event_name,
@@ -399,7 +399,7 @@ async def test_dict_mutation_detection__plain_list(
         dict_mutation_state: A state with dict mutation features.
     """
     for event_name, expected_delta in event_tuples:
-        result = await dict_mutation_state.process(
+        result = await dict_mutation_state._process(
             Event(
                 token="fake-token",
                 name=event_name,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -576,7 +576,7 @@ async def test_process_event_simple(test_state):
     assert test_state.num1 == 0
 
     event = Event(token="t", name="set_num1", payload={"value": 69})
-    update = await test_state.process(event)
+    update = await test_state._process(event)
 
     # The event should update the value.
     assert test_state.num1 == 69
@@ -601,7 +601,7 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
     event = Event(
         token="t", name="child_state.change_both", payload={"value": "hi", "count": 12}
     )
-    update = await test_state.process(event)
+    update = await test_state._process(event)
     assert child_state.value == "HI"
     assert child_state.count == 24
     assert update.delta == {
@@ -617,7 +617,7 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
         name="child_state.grandchild_state.set_value2",
         payload={"value": "new"},
     )
-    update = await test_state.process(event)
+    update = await test_state._process(event)
     assert grandchild_state.value2 == "new"
     assert update.delta == {
         "test_state.child_state.grandchild_state": {"value2": "new"},


### PR DESCRIPTION
### Description

- closes #834 
- Prevents some of the methods in `state.py` from being overwritten if someone calls event handler built-ins
- Fixes unit tests

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

- [x] Breaking change


