### PR TITLE
Fix pynecone.json version issue when web init(#884)

### DIFF
--- a/pynecone/utils/prerequisites.py
+++ b/pynecone/utils/prerequisites.py
@@ -205,6 +205,12 @@ def initialize_web_directory():
     path_ops.rm(os.path.join(constants.WEB_TEMPLATE_DIR, constants.NODE_MODULES))
     path_ops.rm(os.path.join(constants.WEB_TEMPLATE_DIR, constants.PACKAGE_LOCK))
     path_ops.cp(constants.WEB_TEMPLATE_DIR, constants.WEB_DIR)
+    """Write the current version of distributed pynecone package to a PCVERSION_APP_FILE."""
+    with open(constants.PCVERSION_APP_FILE) as f:  # type: ignore
+        pynecone_json = json.load(f)
+        pynecone_json["version"] = constants.VERSION
+    with open(constants.PCVERSION_APP_FILE, "w") as f:
+        json.dump(pynecone_json, f, ensure_ascii=False)
 
 
 def install_bun():


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:


### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.
This pull request is related to the issue https://github.com/pynecone-io/pynecone/issues/884
Sometimes when the core developer upgrades the version, they must remember to change the pynecone.json in the template by hand. And sometimes, we may forget it.
We must prevent the application developer from getting the wrong information from pynecone.json.
Having an intuitive way to have the correct package's version in the `.web/pynecone.json` is better. 
And let's put this action in the web's init. 



    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

