### PR TITLE
Add bun install to fix pc bun package installation Error during run command in Container Image

### DIFF
--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 ENV BUN_INSTALL="/app/.bun"
 COPY --from=build /app/ /app/
 RUN pc init \
-    && /app/.bun/bin/bun install --cwd .web/
+    && bash -c "/app/.bun/bin/bun install --cwd .web/"
 
 
 FROM runtime

--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -34,7 +34,8 @@ FROM runtime as init
 WORKDIR /app
 ENV BUN_INSTALL="/app/.bun"
 COPY --from=build /app/ /app/
-RUN pc init
+RUN pc init \
+    && /app/.bun/bin/bun install cwd=.web/
 
 
 FROM runtime

--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 ENV BUN_INSTALL="/app/.bun"
 COPY --from=build /app/ /app/
 RUN pc init \
-    && /app/.bun/bin/bun install cwd=.web/
+    && /app/.bun/bin/bun install --cwd .web/
 
 
 FROM runtime


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

The PR fixes the pc run error in the container build of Pynecone which causes by the download issue in the production environment of Pynecone. The bun package download is triggered via bun command. That fixed the issue #897.

