### PR TITLE
make argument optional for event handlers

### DIFF
--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -220,7 +220,9 @@ class Component(Base, ABC):
                     event = call_event_handler(v, arg)
 
                     # Check that the event handler takes no args if it's uncontrolled.
-                    if not is_controlled_event and len(event.args) > 0:
+                    if not is_controlled_event and (
+                        event.args is not None and len(event.args) > 0
+                    ):
                         raise ValueError(
                             f"Event handler: {v.fn} for uncontrolled event {event_trigger} should not take any args."
                         )

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -329,9 +329,6 @@ def get_handler_args(
 
     Returns:
         The handler args.
-
-    Raises:
-        ValueError: If the event handler has an invalid signature.
     """
     args = inspect.getfullargspec(event_spec.handler.fn).args
 

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -369,7 +369,7 @@ def fix_events(
             e = e()
         assert isinstance(e, EventSpec), f"Unexpected event type, {type(e)}."
         name = format.format_event_handler(e.handler)
-        payload = {k.name: v.name for k, v in e.args}
+        payload = {k.name: v.name for k, v in e.args} if e.args else {}
 
         # Create an event and append it to the list.
         out.append(

--- a/pynecone/utils/format.py
+++ b/pynecone/utils/format.py
@@ -329,7 +329,7 @@ def format_full_control_event(event_chain: EventChain) -> str:
     from pynecone.compiler import templates
 
     event_spec = event_chain.events[0]
-    arg = event_spec.args[0][1]
+    arg = event_spec.args[0][1] if event_spec.args else None
     state_name = event_chain.state_name
     chain = ",".join([format_event(event) for event in event_chain.events])
     event = templates.FULL_CONTROL(state_name=state_name, arg=arg, chain=chain)

--- a/pynecone/utils/format.py
+++ b/pynecone/utils/format.py
@@ -286,11 +286,17 @@ def format_event(event_spec: EventSpec) -> str:
     Returns:
         The compiled event.
     """
-    args = ",".join(
-        [
-            ":".join((name.name, json.dumps(val.name) if val.is_string else val.name))
-            for name, val in event_spec.args
-        ]
+    args = (
+        ",".join(
+            [
+                ":".join(
+                    (name.name, json.dumps(val.name) if val.is_string else val.name)
+                )
+                for name, val in event_spec.args
+            ]
+        )
+        if event_spec.args is not None
+        else ""
     )
     return f"E(\"{format_event_handler(event_spec.handler)}\", {wrap(args, '{')})"
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -391,13 +391,10 @@ def test_invalid_event_handler_args(component2, test_state):
     # Controlled event handlers should take args.
     # This is okay.
     component2.create(on_open=test_state.do_something_arg)
-    # This is not okay.
-    with pytest.raises(ValueError):
-        component2.create(on_open=test_state.do_something)
-    with pytest.raises(ValueError):
-        component2.create(
-            on_open=[test_state.do_something_arg, test_state.do_something]
-        )
+
+    # do_something is allowed and will simply run while ignoring the arg
+    component2.create(on_open=test_state.do_something)
+    component2.create(on_open=[test_state.do_something_arg, test_state.do_something])
 
 
 def test_get_hooks_nested(component1, component2, component3):


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

Change some method related to EventSpec, to allow for using eventhandler that define less arguments than an event would require. (in this case, the `arg` will be "lost")

closes #862 