### PR TITLE
Cache ComputedVar -- fixup for dynamic route vars

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -484,6 +484,9 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
                 func = arglist_factory(param)
             else:
                 continue
+            # link dynamically created ComputedVar to this state class for dep determination
+            func.__objclass__ = cls
+            func.fget.__name__ = param
             cls.computed_vars[param] = func.set_state(cls)  # type: ignore
             setattr(cls, param, func)
 
@@ -537,7 +540,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         super().__setattr__(name, value)
 
         # Add the var to the dirty list.
-        if name in self.vars:
+        if name in self.vars or name in self.computed_var_dependencies:
             self.dirty_vars.add(name)
             self.mark_dirty()
 

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -487,7 +487,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             # link dynamically created ComputedVar to this state class for dep determination
             func.__objclass__ = cls
             func.fget.__name__ = param
-            cls.computed_vars[param] = func.set_state(cls)  # type: ignore
+            cls.vars[param] = cls.computed_vars[param] = func.set_state(cls)  # type: ignore
             setattr(cls, param, func)
 
     def __getattribute__(self, name: str) -> Any:

--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -851,6 +851,10 @@ class ComputedVar(property, Var):
 
         Returns:
             A set of variable names accessed by the given obj.
+
+        Raises:
+            RuntimeError: if this ComputedVar does not have a reference to the class
+                it is attached to. (Assign var.__objclass__ manually to workaround.)
         """
         d = set()
         if obj is None:
@@ -870,6 +874,10 @@ class ComputedVar(property, Var):
             if self_is_top_of_stack and instruction.opname == "LOAD_ATTR":
                 d.add(instruction.argval)
             elif self_is_top_of_stack and instruction.opname == "LOAD_METHOD":
+                if not hasattr(self, "__objclass__"):
+                    raise RuntimeError(
+                        f"ComputedVar {self.name!r} is not bound to a State subclass.",
+                    )
                 d.update(self.deps(obj=getattr(self.__objclass__, instruction.argval)))
             self_is_top_of_stack = False
         return d

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,6 +105,25 @@ def test_add_page_set_route(app: App, index_page, windows_platform: bool):
     assert set(app.pages.keys()) == {"test"}
 
 
+def test_add_page_set_route_dynamic(app: App, index_page, windows_platform: bool):
+    """Test adding a page with dynamic route variable to an app.
+
+    Args:
+        app: The app to test.
+        index_page: The index page.
+        windows_platform: Whether the system is windows.
+    """
+    route = "/test/[dynamic]"
+    if windows_platform:
+        route.lstrip("/").replace("/", "\\")
+    assert app.pages == {}
+    app.add_page(index_page, route=route)
+    assert set(app.pages.keys()) == {"test/[dynamic]"}
+    assert "dynamic" in app.state.computed_vars
+    assert app.state.computed_vars["dynamic"].deps() == {"router_data"}
+    assert "router_data" in app.state().computed_var_dependencies
+
+
 def test_add_page_set_route_nested(app: App, index_page, windows_platform: bool):
     """Test adding a page to an app.
 


### PR DESCRIPTION
An issue was identified and described in #917, which found a problem calculating dependencies of dynamically added route vars (`setup_dynamic_vars`). When `ComputedVar` are created and added directly to the state class `computed_vars` dict, they may not get a reference to the state class, since `__init_subclass__` has already executed. In this case, assign the `__obj_class__` attribute directly.

Bonus fix: set the `inner_func` name appropriately so that it can be accessed via props.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?


### Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?