### PR TITLE
patch server_side event with function signature

### DIFF
--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -139,11 +139,12 @@ class FileUpload(Base):
 
 
 # Special server-side events.
-def server_side(name: str, **kwargs) -> EventSpec:
+def server_side(name: str, sig: inspect.Signature, **kwargs) -> EventSpec:
     """A server-side event.
 
     Args:
         name: The name of the event.
+        sig: The function signature of the event.
         **kwargs: The arguments to pass to the event.
 
     Returns:
@@ -154,6 +155,7 @@ def server_side(name: str, **kwargs) -> EventSpec:
         return None
 
     fn.__qualname__ = name
+    fn.__signature__ = sig
     return EventSpec(
         handler=EventHandler(fn=fn),
         args=tuple(
@@ -172,7 +174,7 @@ def redirect(path: Union[str, Var[str]]) -> EventSpec:
     Returns:
         An event to redirect to the path.
     """
-    return server_side("_redirect", path=path)
+    return server_side("_redirect", get_fn_signature(redirect), path=path)
 
 
 def console_log(message: Union[str, Var[str]]) -> EventSpec:
@@ -184,7 +186,7 @@ def console_log(message: Union[str, Var[str]]) -> EventSpec:
     Returns:
         An event to log the message.
     """
-    return server_side("_console", message=message)
+    return server_side("_console", get_fn_signature(console_log), message=message)
 
 
 def window_alert(message: Union[str, Var[str]]) -> EventSpec:
@@ -196,7 +198,7 @@ def window_alert(message: Union[str, Var[str]]) -> EventSpec:
     Returns:
         An event to alert the message.
     """
-    return server_side("_alert", message=message)
+    return server_side("_alert", get_fn_signature(window_alert), message=message)
 
 
 def set_value(ref: str, value: Any) -> EventSpec:
@@ -210,7 +212,10 @@ def set_value(ref: str, value: Any) -> EventSpec:
         An event to set the ref.
     """
     return server_side(
-        "_set_value", ref=Var.create_safe(format.format_ref(ref)), value=value
+        "_set_value",
+        get_fn_signature(set_value),
+        ref=Var.create_safe(format.format_ref(ref)),
+        value=value,
     )
 
 
@@ -330,11 +335,7 @@ def get_handler_args(event_spec: EventSpec, arg: Var) -> Tuple[Tuple[Var, Var], 
     """
     args = inspect.getfullargspec(event_spec.handler.fn).args
 
-    return (
-        event_spec.args
-        if len(args) > 2
-        else (((Var.create_safe(args[1]), arg),) if len(args) == 2 else tuple())
-    )
+    return event_spec.args if len(args) > 1 else tuple()
 
 
 def fix_events(
@@ -379,6 +380,22 @@ def fix_events(
         )
 
     return out
+
+
+def get_fn_signature(fn: Callable) -> inspect.Signature:
+    """Get the signature of a function.
+
+    Args:
+        fn: The function.
+
+    Returns:
+        The signature of the function.
+    """
+    signature = inspect.signature(fn)
+    new_param = inspect.Parameter(
+        "state", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Any
+    )
+    return signature.replace(parameters=(new_param, *signature.parameters.values()))
 
 
 # A set of common event triggers.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?


### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

Tested with the below code
```python
"""Welcome to Pynecone! This file create a counter app."""
import pynecone as pc
from pynecone.vars import BaseVar

class State(pc.State):
    """The app state."""
    def test_log(self, msg):
        return pc.console_log(f"from server: {msg}")

def index():
    """The main view."""
    output =  pc.vstack(
        pc.input(id="text1"),
        pc.input(id="text2"),
        pc.select(
            [1,2,3],
            on_change=[
                lambda e: pc.set_value("text1", e),
                pc.set_value("text2", "abc"),
                pc.console_log(message=BaseVar(name="ref_text1.current.value", is_local=True, is_string=False)),
                lambda e: State.test_log(e),
                lambda e: pc.window_alert(e),
                
            ]
        ),
    )
    return output
# Add state and page to the app.
app = pc.App(state=State)
app.add_page(index, title="Chatbox")
app.compile()
```

Not sure if the change to get_handler_args is correct or not, please advise.

closes #1006