### PR TITLE
move add ref to component level render

### DIFF
--- a/pynecone/components/component.py
+++ b/pynecone/components/component.py
@@ -320,6 +320,11 @@ class Component(Base, ABC):
         if hasattr(self, "as_"):
             props["as"] = self.as_  # type: ignore
 
+        # Add ref to element if `id` is not None.
+        ref = self.get_ref()
+        if ref is not None:
+            props["ref"] = Var.create(ref, is_local=False)
+
         return tag.add_props(**props)
 
     @classmethod

--- a/pynecone/components/forms/input.py
+++ b/pynecone/components/forms/input.py
@@ -70,13 +70,6 @@ class Input(ChakraComponent):
             "on_key_up": EVENT_ARG.key,
         }
 
-    def _render(self):
-        out = super()._render()
-        ref = self.get_ref()
-        if ref is not None:
-            out.add_props(ref=Var.create(ref, is_local=False))
-        return out
-
 
 class InputGroup(ChakraComponent):
     """The InputGroup component is a component that is used to group a set of inputs."""


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

The prop `ref` should not be only limited to component of type input.
Moving the logic to component level render, so other components can use this prop
