### PR TITLE
bugfix for upload event

### DIFF
--- a/pynecone/utils/format.py
+++ b/pynecone/utils/format.py
@@ -298,8 +298,7 @@ def format_event(event_spec: EventSpec) -> str:
     event_args = [
         wrap(format_event_handler(event_spec.handler), '"'),
     ]
-    if len(args) > 0:
-        event_args.append(wrap(args, "{"))
+    event_args.append(wrap(args, "{"))
 
     if event_spec.client_handler_name:
         event_args.append(wrap(event_spec.client_handler_name, '"'))

--- a/tests/components/test_tag.py
+++ b/tests/components/test_tag.py
@@ -25,7 +25,7 @@ def mock_event(arg):
         ({"a": 1, "b": 2, "c": 3}, '{{"a": 1, "b": 2, "c": 3}}'),
         (
             EventChain(events=[EventSpec(handler=EventHandler(fn=mock_event))]),
-            '{_e => Event([E("mock_event")], _e)}',
+            '{_e => Event([E("mock_event", {})], _e)}',
         ),
         (
             EventChain(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -46,7 +46,7 @@ def test_call_event_handler():
 
     assert event_spec.handler == handler
     assert event_spec.args == ()
-    assert format.format_event(event_spec) == 'E("test_fn")'
+    assert format.format_event(event_spec) == 'E("test_fn", {})'
 
     handler = EventHandler(fn=test_fn_with_args)
     event_spec = handler(make_var("first"), make_var("second"))


### PR DESCRIPTION
### All Submissions:
Fix for upload event error:
```
    event = Event.parse_raw(data)
            ^^^^^^^^^^^^^^^^^^^^^
  File "pydantic/main.py", line 549, in pydantic.main.BaseModel.parse_raw
  File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Event
payload
  value is not a valid dict (type=type_error.dict)
```
- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

