### PR TITLE
Validation for components with unsupported children

### DIFF
--- a/pynecone/components/datadisplay/table.py
+++ b/pynecone/components/datadisplay/table.py
@@ -1,4 +1,5 @@
 """Table components."""
+from typing import List
 
 from pynecone.components.component import Component
 from pynecone.components.layout.foreach import Foreach
@@ -62,6 +63,9 @@ class Thead(ChakraComponent):
 
     tag = "Thead"
 
+    # invalid children components
+    invalid_children: List[str] = ["Tbody", "Thead", "Tfoot"]
+
     @classmethod
     def create(cls, *children, headers=None, **props) -> Component:
         """Create a table header component.
@@ -83,6 +87,9 @@ class Tbody(ChakraComponent):
     """A table body component."""
 
     tag = "Tbody"
+
+    # invalid children components
+    invalid_children: List[str] = ["Tbody", "Thead", "Tfoot", "Td", "Th"]
 
     @classmethod
     def create(cls, *children, rows=None, **props) -> Component:
@@ -106,6 +113,9 @@ class Tfoot(ChakraComponent):
 
     tag = "Tfoot"
 
+    # invalid children components
+    invalid_children: List[str] = ["Tbody", "Thead", "Td", "Th", "Tfoot"]
+
     @classmethod
     def create(cls, *children, footers=None, **props) -> Component:
         """Create a table footer component.
@@ -127,6 +137,9 @@ class Tr(ChakraComponent):
     """A table row component."""
 
     tag = "Tr"
+
+    # invalid children components
+    invalid_children: List[str] = ["Tbody", "Thead", "Tfoot", "Tr"]
 
     @classmethod
     def create(cls, *children, cell_type: str = "", cells=None, **props) -> Component:
@@ -156,6 +169,9 @@ class Th(ChakraComponent):
 
     tag = "Th"
 
+    # invalid children components
+    invalid_children: List[str] = ["Tbody", "Thead", "Tr", "Td", "Th"]
+
     # Aligns the cell content to the right.
     is_numeric: Var[bool]
 
@@ -164,6 +180,9 @@ class Td(ChakraComponent):
     """A table data cell component."""
 
     tag = "Td"
+
+    # invalid children components
+    invalid_children: List[str] = ["Tbody", "Thead"]
 
     # Aligns the cell content to the right.
     is_numeric: Var[bool]

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -113,6 +113,22 @@ def component4() -> Type[Component]:
 
 
 @pytest.fixture
+def component5() -> Type[Component]:
+    """A test component.
+
+    Returns:
+        A test component.
+    """
+
+    class TestComponent5(Component):
+        tag = "Tag"
+
+        invalid_children: List[str] = ["Text"]
+
+    return TestComponent5
+
+
+@pytest.fixture
 def on_click1() -> EventHandler:
     """A sample on click function.
 
@@ -432,4 +448,19 @@ def test_get_hooks_nested2(component3, component4):
             component3.create(),
         ).get_hooks()
         == exp_hooks
+    )
+
+
+def test_unsupported_child_components(component5):
+    """Test that a value error is raised when an unsupported component is provided as a child.
+
+    Args:
+        component5: the test component
+    """
+    with pytest.raises(ValueError) as err:
+        comp = component5.create(pc.text("testing component"))
+        comp.render()
+    assert (
+        err.value.args[0]
+        == f"The component `tag` cannot have `text` as a child component"
     )


### PR DESCRIPTION
This PR Adds a  validation check that throws an error when an unsupported component is passed as a child to a component.
This is achieved by specifying an `invalid_children` field with a list of Tag names of unsupported components.

fixes #1065 