### PR TITLE
Backend host cli arg

### DIFF
--- a/pynecone/config.py
+++ b/pynecone/config.py
@@ -134,6 +134,9 @@ class Config(Base):
     # The frontend port.
     backend_port: str = constants.BACKEND_PORT
 
+    # The backend host.
+    backend_host: str = constants.BACKEND_HOST
+
     # The backend API url.
     api_url: str = constants.API_URL
 

--- a/pynecone/pc.py
+++ b/pynecone/pc.py
@@ -74,6 +74,7 @@ def run(
     ),
     port: str = typer.Option(None, help="Specify a different frontend port."),
     backend_port: str = typer.Option(None, help="Specify a different backend port."),
+    backend_host: str = typer.Option(None, help="Specify the backend host."),
 ):
     """Run the app in the current directory."""
     if platform.system() == "Windows":
@@ -83,6 +84,7 @@ def run(
 
     frontend_port = get_config().port if port is None else port
     backend_port = get_config().backend_port if backend_port is None else backend_port
+    backend_host = get_config().backend_host if backend_host is None else backend_host
 
     # If no --frontend-only and no --backend-only, then turn on frontend and backend both
     if not frontend and not backend:
@@ -126,10 +128,10 @@ def run(
     telemetry.send(f"run-{env.value}", get_config().telemetry_enabled)
 
     # Run the frontend and backend.
-    # try:
     if backend:
         threading.Thread(
-            target=backend_cmd, args=(app.__name__, backend_port, loglevel)
+            target=backend_cmd,
+            args=(app.__name__, backend_host, backend_port, loglevel),
         ).start()
     if frontend:
         threading.Thread(

--- a/pynecone/utils/exec.py
+++ b/pynecone/utils/exec.py
@@ -132,11 +132,15 @@ def run_frontend_prod(
 
 
 def run_backend(
-    app_name: str, port: int, loglevel: constants.LogLevel = constants.LogLevel.ERROR
+    app_name: str,
+    host: str,
+    port: int,
+    loglevel: constants.LogLevel = constants.LogLevel.ERROR,
 ):
     """Run the backend.
 
     Args:
+        host: The app host
         app_name: The app name.
         port: The app port
         loglevel: The log level.
@@ -147,7 +151,7 @@ def run_backend(
         "uvicorn",
         f"{app_name}:{constants.APP_VAR}.{constants.API_VAR}",
         "--host",
-        constants.BACKEND_HOST,
+        host,
         "--port",
         str(port),
         "--log-level",
@@ -163,11 +167,15 @@ def run_backend(
 
 
 def run_backend_prod(
-    app_name: str, port: int, loglevel: constants.LogLevel = constants.LogLevel.ERROR
+    app_name: str,
+    host: str,
+    port: int,
+    loglevel: constants.LogLevel = constants.LogLevel.ERROR,
 ):
     """Run the backend.
 
     Args:
+        host: The app host
         app_name: The app name.
         port: The app port
         loglevel: The log level.
@@ -179,7 +187,7 @@ def run_backend_prod(
         [
             *constants.RUN_BACKEND_PROD_WINDOWS,
             "--host",
-            "0.0.0.0",
+            host,
             "--port",
             str(port),
             f"{app_name}:{constants.APP_VAR}",
@@ -188,7 +196,7 @@ def run_backend_prod(
         else [
             *constants.RUN_BACKEND_PROD,
             "--bind",
-            f"0.0.0.0:{port}",
+            f"{host}:{port}",
             "--threads",
             str(num_workers),
             f"{app_name}:{constants.APP_VAR}()",


### PR DESCRIPTION
This PR adds a `backend-host` cli argument on `pc run` for specifying the host to run the backend on. If you dont specify this, the default `0.0.0.0` will be used.

fixes #1017 
