### PR TITLE
add set_focus

### DIFF
--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -97,6 +97,13 @@ export const applyEvent = async (event, router, socket) => {
     return false;
   }
 
+  if (event.name == "_set_focus") {
+    const ref =
+      event.payload.ref in refs ? refs[event.payload.ref] : event.payload.ref;
+    ref.current.focus();
+    return false;
+  }
+
   if (event.name == "_set_value") {
     const ref =
       event.payload.ref in refs ? refs[event.payload.ref] : event.payload.ref;

--- a/pynecone/__init__.py
+++ b/pynecone/__init__.py
@@ -22,6 +22,7 @@ from .event import EventChain as EventChain
 from .event import FileUpload as upload_files
 from .event import console_log as console_log
 from .event import redirect as redirect
+from .event import set_focus as set_focus
 from .event import set_value as set_value
 from .event import window_alert as window_alert
 from .middleware import Middleware as Middleware

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -201,16 +201,22 @@ def window_alert(message: Union[str, Var[str]]) -> EventSpec:
     """
     return server_side("_alert", get_fn_signature(window_alert), message=message)
 
+
 def set_focus(ref: str) -> EventSpec:
     """Set focus to specified ref.
-    
+
     Args:
         ref: The ref.
-    
+
     Returns:
         An event to set focus on the ref
     """
-    return server_side("_set_focus", get_fn_signature(set_focus),ref=Var.create_safe(format.format_ref(ref)))
+    return server_side(
+        "_set_focus",
+        get_fn_signature(set_focus),
+        ref=Var.create_safe(format.format_ref(ref)),
+    )
+
 
 def set_value(ref: str, value: Any) -> EventSpec:
     """Set the value of a ref.

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -201,6 +201,16 @@ def window_alert(message: Union[str, Var[str]]) -> EventSpec:
     """
     return server_side("_alert", get_fn_signature(window_alert), message=message)
 
+def set_focus(ref: str) -> EventSpec:
+    """Set focus to specified ref.
+    
+    Args:
+        ref: The ref.
+    
+    Returns:
+        An event to set focus on the ref
+    """
+    return server_side("_set_focus", get_fn_signature(set_focus),ref=Var.create_safe(format.format_ref(ref)))
 
 def set_value(ref: str, value: Any) -> EventSpec:
     """Set the value of a ref.

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -118,6 +118,20 @@ def test_event_window_alert():
     assert format.format_event(spec) == 'E("_alert", {message:message})'
 
 
+def test_set_focus():
+    """Test the event set focus function."""
+    spec = event.set_focus("input1")
+    assert isinstance(spec, EventSpec)
+    assert spec.handler.fn.__qualname__ == "_set_focus"
+    assert spec.args == (
+        ("ref", Var.create_safe("ref_input1")),
+    )
+    assert format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
+    spec = event.set_focus("input1", Var.create_safe("message"))
+    assert (
+        format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
+    )
+
 def test_set_value():
     """Test the event window alert function."""
     spec = event.set_value("input1", "")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -123,14 +123,11 @@ def test_set_focus():
     spec = event.set_focus("input1")
     assert isinstance(spec, EventSpec)
     assert spec.handler.fn.__qualname__ == "_set_focus"
-    assert spec.args == (
-        ("ref", Var.create_safe("ref_input1")),
-    )
+    assert spec.args == (("ref", Var.create_safe("ref_input1")),)
     assert format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
     spec = event.set_focus("input1")
-    assert (
-        format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
-    )
+    assert format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
+
 
 def test_set_value():
     """Test the event window alert function."""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -127,7 +127,7 @@ def test_set_focus():
         ("ref", Var.create_safe("ref_input1")),
     )
     assert format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
-    spec = event.set_focus("input1", Var.create_safe("message"))
+    spec = event.set_focus("input1")
     assert (
         format.format_event(spec) == 'E("_set_focus", {ref:ref_input1})'
     )


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?


### Type of change

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?


Example usage
```python
"""Welcome to Pynecone! This file create a counter app."""
import pynecone as pc


class State(pc.State):
    """The app state."""

    count = 0
    text: str


def index():
    """The main view."""
    return pc.center(
        pc.vstack(
            pc.heading(State.count),
            pc.hstack(
                pc.input(id="input1"),
                pc.button("Clear", on_click=lambda: pc.set_focus("input1")),
            ),
        ),
        padding_y="5em",
        font_size="2em",
        text_align="center",
    )


# Add state and page to the app.
app = pc.App(state=State)
app.add_page(index, title="Chatbox")
app.compile()
```

closes #1083 