### PR TITLE
Add async events

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -540,7 +540,7 @@ def upload(app: App):
             payload={handler_upload_param[0]: files},
         )
         # TODO: refactor this to handle yields.
-        update = await anext(state._process(event))
+        update = await state._process(event).__anext__()
         return update
 
     return upload_file

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -458,18 +458,19 @@ async def process(
     # Preprocess the event.
     update = await app.preprocess(state, event)
 
-    # If there was an update, return it.
+    # If there was an update, yield it.
     if update is not None:
         yield update
-        return
 
-    # Process the event.
-    async for update in state._process(event):
-        yield update
+    # Only process the event if there is no update.
+    else:
+        # Process the event.
+        async for update in state._process(event):
+            yield update
 
-    # Postprocess the event.
-    assert update is not None, "Process did not return an update."
-    update = await app.postprocess(state, event, update)
+        # Postprocess the event.
+        assert update is not None, "Process did not return an update."
+        update = await app.postprocess(state, event, update)
 
     # Set the state for the session.
     app.state_manager.set_state(event.token, state)

--- a/pynecone/event.py
+++ b/pynecone/event.py
@@ -30,7 +30,7 @@ class EventHandler(Base):
     """An event handler responds to an event to update the state."""
 
     # The function to call in response to the event.
-    fn: Callable
+    fn: Any
 
     class Config:
         """The Pydantic config."""

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -632,7 +632,6 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         Raises:
             ValueError: If the state value is None.
         """
-        print("state._process")
         # Get the event handler.
         path = event.name.split(".")
         path, name = path[:-1], path[-1]
@@ -658,8 +657,8 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
 
         # TODO: clean this up with the above code.
         delta = self.get_delta()
-        yield StateUpdate(delta=delta, events=[])
         self.clean()
+        yield StateUpdate(delta=delta, events=[])
 
     async def _process_event(
         self, handler: EventHandler, state: State, payload: Dict
@@ -686,7 +685,6 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             elif inspect.isgenerator(events):
                 for event in events:
                     yield event
-            return
         except Exception:
             error = traceback.format_exc()
             print(error)

--- a/tests/middleware/test_hydrate_middleware.py
+++ b/tests/middleware/test_hydrate_middleware.py
@@ -136,13 +136,13 @@ async def test_preprocess_multiple_load_events(hydrate_middleware, event1):
 
     # Apply the events.
     events = update.events
-    update = await state._process(events[0])
+    update = await anext(state._process(events[0]))
     assert update.delta == {"test_state": {"num": 1}}
 
-    update = await state._process(events[1])
+    update = await anext(state._process(events[1]))
     assert update.delta == {"test_state": {"num": 2}}
 
-    update = await state._process(events[2])
+    update = await anext(state._process(events[2]))
     assert update.delta == exp_is_hydrated(state)
 
 
@@ -165,5 +165,5 @@ async def test_preprocess_no_events(hydrate_middleware, event1):
     assert len(update.events) == 1
     assert isinstance(update, StateUpdate)
 
-    update = await state._process(update.events[0])
+    update = await anext(state._process(update.events[0]))
     assert update.delta == exp_is_hydrated(state)

--- a/tests/middleware/test_hydrate_middleware.py
+++ b/tests/middleware/test_hydrate_middleware.py
@@ -107,11 +107,11 @@ async def test_preprocess(State, hydrate_middleware, request, event_fixture, exp
     assert len(events) == 2
 
     # Apply the on_load event.
-    update = await state._process(events[0])
+    update = await state._process(events[0]).__anext__()
     assert update.delta == expected
 
     # Apply the hydrate event.
-    update = await state._process(events[1])
+    update = await state._process(events[1]).__anext__()
     assert update.delta == exp_is_hydrated(state)
 
 
@@ -136,13 +136,13 @@ async def test_preprocess_multiple_load_events(hydrate_middleware, event1):
 
     # Apply the events.
     events = update.events
-    update = await anext(state._process(events[0]))
+    update = await state._process(events[0]).__anext__()
     assert update.delta == {"test_state": {"num": 1}}
 
-    update = await anext(state._process(events[1]))
+    update = await state._process(events[1]).__anext__()
     assert update.delta == {"test_state": {"num": 2}}
 
-    update = await anext(state._process(events[2]))
+    update = await state._process(events[2]).__anext__()
     assert update.delta == exp_is_hydrated(state)
 
 
@@ -165,5 +165,5 @@ async def test_preprocess_no_events(hydrate_middleware, event1):
     assert len(update.events) == 1
     assert isinstance(update, StateUpdate)
 
-    update = await anext(state._process(update.events[0]))
+    update = await state._process(update.events[0]).__anext__()
     assert update.delta == exp_is_hydrated(state)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -207,7 +207,7 @@ async def test_dynamic_var_event(test_state):
             router_data={"pathname": "/", "query": {}},
             payload={"value": 50},
         )
-    )
+    ).__anext__()
     assert result.delta == {"test_state": {"int_val": 50}}
 
 
@@ -317,16 +317,14 @@ async def test_list_mutation_detection__plain_list(
         list_mutation_state: A state with list mutation features.
     """
     for event_name, expected_delta in event_tuples:
-        result = await anext(
-            list_mutation_state._process(
-                Event(
-                    token="fake-token",
-                    name=event_name,
-                    router_data={"pathname": "/", "query": {}},
-                    payload={},
-                )
+        result = await list_mutation_state._process(
+            Event(
+                token="fake-token",
+                name=event_name,
+                router_data={"pathname": "/", "query": {}},
+                payload={},
             )
-        )
+        ).__anext__()
 
         assert result.delta == expected_delta
 
@@ -446,16 +444,14 @@ async def test_dict_mutation_detection__plain_list(
         dict_mutation_state: A state with dict mutation features.
     """
     for event_name, expected_delta in event_tuples:
-        result = await anext(
-            dict_mutation_state._process(
-                Event(
-                    token="fake-token",
-                    name=event_name,
-                    router_data={"pathname": "/", "query": {}},
-                    payload={},
-                )
+        result = await dict_mutation_state._process(
+            Event(
+                token="fake-token",
+                name=event_name,
+                router_data={"pathname": "/", "query": {}},
+                payload={},
             )
-        )
+        ).__anext__()
 
         assert result.delta == expected_delta
 
@@ -643,15 +639,14 @@ async def test_dynamic_route_var_route_change_completed_on_load(
         )
 
     for exp_index, exp_val in enumerate(exp_vals):
-        update = await anext(
-            process(
-                app,
-                event=_event(name=get_hydrate_event(state), val=exp_val),
-                sid=sid,
-                headers={},
-                client_ip=client_ip,
-            )
-        )
+        update = await process(
+            app,
+            event=_event(name=get_hydrate_event(state), val=exp_val),
+            sid=sid,
+            headers={},
+            client_ip=client_ip,
+        ).__anext__()
+
         # route change triggers: [full state dict, call on_load events, call set_is_hydrated(True)]
         assert update == StateUpdate(
             delta={
@@ -675,15 +670,13 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             ],
         )
         assert state.dynamic == exp_val
-        on_load_update = await anext(
-            process(
-                app,
-                event=_dynamic_state_event(name="on_load", val=exp_val),
-                sid=sid,
-                headers={},
-                client_ip=client_ip,
-            )
-        )
+        on_load_update = await process(
+            app,
+            event=_dynamic_state_event(name="on_load", val=exp_val),
+            sid=sid,
+            headers={},
+            client_ip=client_ip,
+        ).__anext__()
         assert on_load_update == StateUpdate(
             delta={
                 state.get_name(): {
@@ -695,17 +688,15 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             },
             events=[],
         )
-        on_set_is_hydrated_update = await anext(
-            process(
-                app,
-                event=_dynamic_state_event(
-                    name="set_is_hydrated", payload={"value": True}, val=exp_val
-                ),
-                sid=sid,
-                headers={},
-                client_ip=client_ip,
-            )
-        )
+        on_set_is_hydrated_update = await process(
+            app,
+            event=_dynamic_state_event(
+                name="set_is_hydrated", payload={"value": True}, val=exp_val
+            ),
+            sid=sid,
+            headers={},
+            client_ip=client_ip,
+        ).__anext__()
         assert on_set_is_hydrated_update == StateUpdate(
             delta={
                 state.get_name(): {
@@ -719,15 +710,13 @@ async def test_dynamic_route_var_route_change_completed_on_load(
         )
 
         # a simple state update event should NOT trigger on_load or route var side effects
-        update = await anext(
-            process(
-                app,
-                event=_dynamic_state_event(name="on_counter", val=exp_val),
-                sid=sid,
-                headers={},
-                client_ip=client_ip,
-            )
-        )
+        update = await process(
+            app,
+            event=_dynamic_state_event(name="on_counter", val=exp_val),
+            sid=sid,
+            headers={},
+            client_ip=client_ip,
+        ).__anext__()
         assert update == StateUpdate(
             delta={
                 state.get_name(): {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -317,12 +317,14 @@ async def test_list_mutation_detection__plain_list(
         list_mutation_state: A state with list mutation features.
     """
     for event_name, expected_delta in event_tuples:
-        result = await list_mutation_state._process(
-            Event(
-                token="fake-token",
-                name=event_name,
-                router_data={"pathname": "/", "query": {}},
-                payload={},
+        result = await anext(
+            list_mutation_state._process(
+                Event(
+                    token="fake-token",
+                    name=event_name,
+                    router_data={"pathname": "/", "query": {}},
+                    payload={},
+                )
             )
         )
 
@@ -444,12 +446,14 @@ async def test_dict_mutation_detection__plain_list(
         dict_mutation_state: A state with dict mutation features.
     """
     for event_name, expected_delta in event_tuples:
-        result = await dict_mutation_state._process(
-            Event(
-                token="fake-token",
-                name=event_name,
-                router_data={"pathname": "/", "query": {}},
-                payload={},
+        result = await anext(
+            dict_mutation_state._process(
+                Event(
+                    token="fake-token",
+                    name=event_name,
+                    router_data={"pathname": "/", "query": {}},
+                    payload={},
+                )
             )
         )
 
@@ -639,12 +643,14 @@ async def test_dynamic_route_var_route_change_completed_on_load(
         )
 
     for exp_index, exp_val in enumerate(exp_vals):
-        update = await process(
-            app,
-            event=_event(name=get_hydrate_event(state), val=exp_val),
-            sid=sid,
-            headers={},
-            client_ip=client_ip,
+        update = await anext(
+            process(
+                app,
+                event=_event(name=get_hydrate_event(state), val=exp_val),
+                sid=sid,
+                headers={},
+                client_ip=client_ip,
+            )
         )
         # route change triggers: [full state dict, call on_load events, call set_is_hydrated(True)]
         assert update == StateUpdate(
@@ -669,12 +675,14 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             ],
         )
         assert state.dynamic == exp_val
-        on_load_update = await process(
-            app,
-            event=_dynamic_state_event(name="on_load", val=exp_val),
-            sid=sid,
-            headers={},
-            client_ip=client_ip,
+        on_load_update = await anext(
+            process(
+                app,
+                event=_dynamic_state_event(name="on_load", val=exp_val),
+                sid=sid,
+                headers={},
+                client_ip=client_ip,
+            )
         )
         assert on_load_update == StateUpdate(
             delta={
@@ -687,14 +695,16 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             },
             events=[],
         )
-        on_set_is_hydrated_update = await process(
-            app,
-            event=_dynamic_state_event(
-                name="set_is_hydrated", payload={"value": True}, val=exp_val
-            ),
-            sid=sid,
-            headers={},
-            client_ip=client_ip,
+        on_set_is_hydrated_update = await anext(
+            process(
+                app,
+                event=_dynamic_state_event(
+                    name="set_is_hydrated", payload={"value": True}, val=exp_val
+                ),
+                sid=sid,
+                headers={},
+                client_ip=client_ip,
+            )
         )
         assert on_set_is_hydrated_update == StateUpdate(
             delta={
@@ -709,12 +719,14 @@ async def test_dynamic_route_var_route_change_completed_on_load(
         )
 
         # a simple state update event should NOT trigger on_load or route var side effects
-        update = await process(
-            app,
-            event=_dynamic_state_event(name="on_counter", val=exp_val),
-            sid=sid,
-            headers={},
-            client_ip=client_ip,
+        update = await anext(
+            process(
+                app,
+                event=_dynamic_state_event(name="on_counter", val=exp_val),
+                sid=sid,
+                headers={},
+                client_ip=client_ip,
+            )
         )
         assert update == StateUpdate(
             delta={

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -91,6 +91,25 @@ class GrandchildState(ChildState):
         pass
 
 
+class GenState(State):
+    """A state with event handlers that generate multiple updates."""
+
+    value: int
+
+    def go(self, c: int):
+        """Increment the value c times and update each time.
+
+        Args:
+            c: The number of times to increment.
+
+        Yields:
+            After each increment.
+        """
+        for _ in range(c):
+            self.value += 1
+            yield
+
+
 @pytest.fixture
 def test_state() -> TestState:
     """A state.
@@ -144,6 +163,16 @@ def grandchild_state(child_state) -> GrandchildState:
     grandchild_state = child_state.get_substate(["grandchild_state"])
     assert grandchild_state is not None
     return grandchild_state
+
+
+@pytest.fixture
+def gen_state() -> GenState:
+    """A state.
+
+    Returns:
+        A test state.
+    """
+    return GenState()  # type: ignore
 
 
 def test_base_class_vars(test_state):
@@ -625,6 +654,31 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
         "test_state": {"sum": 3.14, "upper": ""},
         "test_state.child_state.grandchild_state": {"value2": "new"},
     }
+
+
+@pytest.mark.asyncio
+async def test_process_event_generator(gen_state):
+    """Test event handlers that generate multiple updates.
+
+    Args:
+        gen_state: A state.
+    """
+    event = Event(
+        token="t",
+        name="go",
+        payload={"c": 5},
+    )
+    gen = gen_state._process(event)
+
+    count = 0
+    async for update in gen:
+        count += 1
+        assert gen_state.value == count
+        assert update.delta == {
+            "gen_state": {"value": count},
+        }
+
+    assert count == 5
 
 
 def test_format_event_handler():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -577,7 +577,7 @@ async def test_process_event_simple(test_state):
     assert test_state.num1 == 0
 
     event = Event(token="t", name="set_num1", payload={"value": 69})
-    update = await test_state._process(event)
+    update = await test_state._process(event).__anext__()
 
     # The event should update the value.
     assert test_state.num1 == 69
@@ -603,7 +603,7 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
     event = Event(
         token="t", name="child_state.change_both", payload={"value": "hi", "count": 12}
     )
-    update = await test_state._process(event)
+    update = await test_state._process(event).__anext__()
     assert child_state.value == "HI"
     assert child_state.count == 24
     assert update.delta == {
@@ -619,7 +619,7 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
         name="child_state.grandchild_state.set_value2",
         payload={"value": "new"},
     )
-    update = await test_state._process(event)
+    update = await test_state._process(event).__anext__()
     assert grandchild_state.value2 == "new"
     assert update.delta == {
         "test_state": {"sum": 3.14, "upper": ""},


### PR DESCRIPTION
This feature allows us to yield multiple state updates from an event handler.

This is a breaking change in how the main processing loop works.

Example code:

```python
"""Welcome to Pynecone! This file create a counter app."""
import random

import asyncio
import pynecone as pc


class State(pc.State):
    """The app state."""

    count = 0

    async def go(self):
        for _ in range(5):
            await asyncio.sleep(0.5)
            self.count += 1
            # Every yield will trigger a state update on the frontend.
            yield


def index() -> pc.Component:
    return pc.center(
        pc.vstack(
            pc.heading(State.count),
            pc.hstack(
                pc.button(
                    "Go",
                    on_click=State.go,
                    background_image="linear-gradient(90deg, rgba(255,0,0,1) 0%, rgba(0,176,34,1) 100%)",
                    color="white",
                ),
            ),
            padding="1em",
            bg="#ededed",
            border_radius="1em",
            box_shadow="lg",
        ),
        padding_y="5em",
        font_size="2em",
        text_align="center",
    )


# Add state and page to the app.
app = pc.App(state=State)
app.add_page(index, title="Counter")
app.compile()
```


https://github.com/pynecone-io/pynecone/assets/6270214/7916fcb7-4aa5-44b5-b89e-3d2d3123e9b7

