### PR TITLE
fix: table get general type

### DIFF
--- a/pynecone/components/datadisplay/table.py
+++ b/pynecone/components/datadisplay/table.py
@@ -40,6 +40,9 @@ class Table(ChakraComponent):
 
         Returns:
             The table component.
+
+        Raises:
+            ValueError: if child length is not zero.
         """
         if len(children) == 0:
             children = []
@@ -55,6 +58,10 @@ class Table(ChakraComponent):
 
             if footers:
                 children.append(Tfoot.create(footers=footers))
+        else:
+            raise ValueError(
+                f"The length of children must be zero but get length {len(children)}"
+            )
         return super().create(*children, **props)
 
 
@@ -77,9 +84,16 @@ class Thead(ChakraComponent):
 
         Returns:
             The table header component.
+
+        Raises:
+            ValueError: if child length is not zero.
         """
         if len(children) == 0:
             children = [Tr.create(cell_type="header", cells=headers)]
+        else:
+            raise ValueError(
+                f"The length of children must be zero but get length {len(children)}"
+            )
         return super().create(*children, **props)
 
 
@@ -102,9 +116,22 @@ class Tbody(ChakraComponent):
 
         Returns:
             Component: _description_
+
+        Raises:
+            ValueError: if child length is not zero.
         """
         if len(children) == 0:
-            children = [Tr.create(cell_type="data", cells=row) for row in rows or []]
+            if isinstance(rows, Var):
+                children = [Foreach.create(rows, Tr.create)]
+            else:
+                children = [
+                    Tr.create(cell_type="data", cells=row) for row in rows or []
+                ]
+        else:
+            raise ValueError(
+                f"The length of children must be zero but get length {len(children)}"
+            )
+
         return super().create(*children, **props)
 
 
@@ -127,9 +154,16 @@ class Tfoot(ChakraComponent):
 
         Returns:
             The table footer component.
+
+        Raises:
+            ValueError: if child length is not zero.
         """
         if len(children) == 0:
             children = [Tr.create(cell_type="header", cells=footers)]
+        else:
+            raise ValueError(
+                f"The length of children must be zero but get length {len(children)}"
+            )
         return super().create(*children, **props)
 
 
@@ -153,14 +187,24 @@ class Tr(ChakraComponent):
 
         Returns:
             The table row component
+
+        Raises:
+            ValueError: if child length is not zero or one.
         """
         types = {"header": Th, "data": Td}
         cell_cls = types.get(cell_type)
+        # Caller is Thead or TFooter
         if len(children) == 0 and cell_cls:
             if isinstance(cells, Var):
                 children = [Foreach.create(cells, cell_cls.create)]
             else:
                 children = [cell_cls.create(cell) for cell in cells or []]
+        elif len(children) == 1:  # Caller is Tbody
+            children = [Foreach.create(children[0], Td.create)]
+        else:
+            raise ValueError(
+                f"The length of children must be zero or one but get length {len(children)}"
+            )
         return super().create(*children, **props)
 
 


### PR DESCRIPTION
Fix issue: https://github.com/pynecone-io/pynecone/issues/752

### All Submissions:

- [X] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [X] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [X] Does your submission pass the tests? 
- [X] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.
fix #752

The main problem is the variable is converted to BaseVar and it lost the real value.
When we call Table.create , children will call Tbody.create and then Tr.create for row in rows.
But actually the rows is BaseVar so the row is field of BaseVar. 

    b. Describe your changes.
Use foreach component to iterator Tbody and Trow and raise ValueError if the input is not as excepted for all table component.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
close #752 
