### PR TITLE
UI connection warning:

### DIFF
--- a/pynecone/.templates/jinja/web/pages/index.js.jinja2
+++ b/pynecone/.templates/jinja/web/pages/index.js.jinja2
@@ -11,6 +11,7 @@
 export default function Component() {
   const [{{state_name}}, {{state_name|react_setter}}] = useState({{initial_state|json_dumps}})
   const [{{const.result}}, {{const.result|react_setter}}] = useState({{const.initial_result|json_dumps}})
+  const [notConnected, setNotConnected] = useState(false)
   const {{const.router}} = useRouter()
   const {{const.socket}} = useRef(null)
   const { isReady } = {{const.router}}
@@ -35,7 +36,7 @@ export default function Component() {
       return;
     }
     if (!{{const.socket}}.current) {
-      connect({{const.socket}}, {{state_name}}, {{state_name|react_setter}}, {{const.result}}, {{const.result|react_setter}}, {{const.router}}, {{transports}})
+      connect({{const.socket}}, {{state_name}}, {{state_name|react_setter}}, {{const.result}}, {{const.result|react_setter}}, {{const.router}}, {{transports}}, setNotConnected)
     }
     const update = async () => {
       if ({{const.result}}.{{const.state}} != null){
@@ -70,7 +71,21 @@ export default function Component() {
   {% endfor %}
 
   return (
+  <Fragment>
+      <Fragment>
+        {notConnected ? (
+          <Box sx={% raw %}{{"text-align": "center"}}{% endraw %}>
+            <Text sx={% raw %}{{ "bg": "red", "color": "white"}}{% endraw %}>
+              {`cannot connect to server. check if server is reachable.`}
+              </Text>
+          </Box>
+        ) : (
+          <Fragment>
+          </Fragment>
+        )}
+      </Fragment>
     {{utils.render(render, indent_width=0)}}
+    </Fragment>
   )
 }
 {% endblock %}

--- a/pynecone/.templates/jinja/web/pages/index.js.jinja2
+++ b/pynecone/.templates/jinja/web/pages/index.js.jinja2
@@ -74,7 +74,7 @@ export default function Component() {
   <Fragment>
       <Fragment>
         {notConnected ? (
-          <Box sx={% raw %}{{"text-align": "center"}}{% endraw %}>
+          <Box sx={% raw %}{{"textAlign": "center"}}{% endraw %}>
             <Text sx={% raw %}{{ "bg": "red", "color": "white"}}{% endraw %}>
               {`cannot connect to server. check if server is reachable.`}
               </Text>

--- a/pynecone/.templates/jinja/web/pages/index.js.jinja2
+++ b/pynecone/.templates/jinja/web/pages/index.js.jinja2
@@ -72,18 +72,9 @@ export default function Component() {
 
   return (
   <Fragment>
-      <Fragment>
-        {notConnected ? (
-          <Box sx={% raw %}{{"textAlign": "center"}}{% endraw %}>
-            <Text sx={% raw %}{{ "bg": "red", "color": "white"}}{% endraw %}>
-              {`cannot connect to server. check if server is reachable.`}
-              </Text>
-          </Box>
-        ) : (
-          <Fragment>
-          </Fragment>
-        )}
-      </Fragment>
+      {%- if err_comp -%}
+            {{ utils.render(err_comp, indent_width=1) }}
+       {%- endif -%}
     {{utils.render(render, indent_width=0)}}
     </Fragment>
   )

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -193,9 +193,11 @@ export const connect = async (
   result,
   setResult,
   router,
-  transports
+  transports,
+  setNotConnected
 ) => {
   // Get backend URL object from the endpoint
+  console.log("event url", EVENTURL);
   const endpoint_url = new URL(EVENTURL);
   // Create the socket.
   socket.current = io(EVENTURL, {
@@ -207,6 +209,12 @@ export const connect = async (
   // Once the socket is open, hydrate the page.
   socket.current.on("connect", () => {
     updateState(state, setState, result, setResult, router, socket.current);
+    setNotConnected(false)
+  });
+
+  socket.current.on('connect_error', (error) => {
+    console.log('Failed to connect to WebSocket', error);
+    setNotConnected(true)
   });
 
   // On each received message, apply the delta and set the result.

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -197,7 +197,6 @@ export const connect = async (
   setNotConnected
 ) => {
   // Get backend URL object from the endpoint
-  console.log("event url", EVENTURL);
   const endpoint_url = new URL(EVENTURL);
   // Create the socket.
   socket.current = io(EVENTURL, {

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -213,7 +213,6 @@ export const connect = async (
   });
 
   socket.current.on('connect_error', (error) => {
-    console.log('Failed to connect to WebSocket', error);
     setNotConnected(true)
   });
 

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -67,10 +67,7 @@ class App(Base):
     load_events: Dict[str, List[EventHandler]] = {}
 
     # The component to render if there is a connection error to the server.
-    connect_error_component: Optional[Component] = None
-
-    # Whether to render component if server cant be reached.
-    check_connection: Optional[bool] = True
+    connect_error_component: Optional[Component] = ConnectionBanner.create()
 
     def __init__(self, *args, **kwargs):
         """Initialize the app.
@@ -410,13 +407,11 @@ class App(Base):
         custom_components = set()
         for route, component in self.pages.items():
             component.add_style(self.style)
-            if not self.connect_error_component:
-                self.connect_error_component = ConnectionBanner.create()
             compiler.compile_page(
                 route,
                 component,
                 self.state,
-                self.connect_error_component if self.check_connection else None,
+                self.connect_error_component,
             )
 
             # Add the custom components from the page to the set.

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -31,7 +31,7 @@ DEFAULT_IMPORTS: imports.ImportDict = {
         ImportVar(tag="getRefValue"),
     },
     "": {ImportVar(tag="focus-visible/dist/focus-visible")},
-    "@chakra-ui/react": {ImportVar(tag=constants.USE_COLOR_MODE)},
+    "@chakra-ui/react": {ImportVar(tag=constants.USE_COLOR_MODE), ImportVar(tag="Box")},
 }
 
 

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -67,16 +67,20 @@ def _compile_theme(theme: dict) -> str:
     return templates.THEME.render(theme=theme)
 
 
-def _compile_page(component: Component, state: Type[State]) -> str:
+def _compile_page(
+    component: Component, state: Type[State], connect_error_component
+) -> str:
     """Compile the component given the app state.
 
     Args:
         component: The component to compile.
         state: The app state.
+        connect_error_component: The component to render on sever connection error.
 
     Returns:
         The compiled component.
     """
+    # breakpoint()
     # Merge the default imports with the app-specific imports.
     imports = utils.merge_imports(DEFAULT_IMPORTS, component.get_imports())
     imports = utils.compile_imports(imports)
@@ -90,6 +94,7 @@ def _compile_page(component: Component, state: Type[State]) -> str:
         hooks=component.get_hooks(),
         render=component.render(),
         transports=constants.Transports.POLLING_WEBSOCKET.get_transports(),
+        err_comp=connect_error_component.render() if connect_error_component else None,
     )
 
 
@@ -193,7 +198,10 @@ def compile_theme(style: Style) -> Tuple[str, str]:
 
 @write_output
 def compile_page(
-    path: str, component: Component, state: Type[State]
+    path: str,
+    component: Component,
+    state: Type[State],
+    connect_error_component: Component,
 ) -> Tuple[str, str]:
     """Compile a single page.
 
@@ -201,6 +209,7 @@ def compile_page(
         path: The path to compile the page to.
         component: The component to compile.
         state: The app state.
+        connect_error_component: The component to render on sever connection error.
 
     Returns:
         The path and code of the compiled page.
@@ -209,7 +218,7 @@ def compile_page(
     output_path = utils.get_page_path(path)
 
     # Add the style to the component.
-    code = _compile_page(component, state)
+    code = _compile_page(component, state, connect_error_component)
     return output_path, code
 
 

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -80,7 +80,6 @@ def _compile_page(
     Returns:
         The compiled component.
     """
-    # breakpoint()
     # Merge the default imports with the app-specific imports.
     imports = utils.merge_imports(DEFAULT_IMPORTS, component.get_imports())
     imports = utils.compile_imports(imports)

--- a/pynecone/compiler/compiler.py
+++ b/pynecone/compiler/compiler.py
@@ -15,6 +15,7 @@ from pynecone.vars import ImportVar
 # Imports to be included in every Pynecone app.
 DEFAULT_IMPORTS: imports.ImportDict = {
     "react": {
+        ImportVar(tag="Fragment"),
         ImportVar(tag="useEffect"),
         ImportVar(tag="useRef"),
         ImportVar(tag="useState"),
@@ -31,7 +32,11 @@ DEFAULT_IMPORTS: imports.ImportDict = {
         ImportVar(tag="getRefValue"),
     },
     "": {ImportVar(tag="focus-visible/dist/focus-visible")},
-    "@chakra-ui/react": {ImportVar(tag=constants.USE_COLOR_MODE), ImportVar(tag="Box")},
+    "@chakra-ui/react": {
+        ImportVar(tag=constants.USE_COLOR_MODE),
+        ImportVar(tag="Box"),
+        ImportVar(tag="Text"),
+    },
 }
 
 

--- a/pynecone/components/__init__.py
+++ b/pynecone/components/__init__.py
@@ -29,6 +29,7 @@ component = Component.create
 badge = Badge.create
 code = Code.create
 code_block = CodeBlock.create
+connection_banner = ConnectionBanner.create
 data_table = DataTable.create
 divider = Divider.create
 list = List.create

--- a/pynecone/components/overlay/__init__.py
+++ b/pynecone/components/overlay/__init__.py
@@ -8,6 +8,7 @@ from .alertdialog import (
     AlertDialogHeader,
     AlertDialogOverlay,
 )
+from .banner import ConnectionBanner
 from .drawer import (
     Drawer,
     DrawerBody,

--- a/pynecone/components/overlay/banner.py
+++ b/pynecone/components/overlay/banner.py
@@ -1,0 +1,33 @@
+"""Banner components."""
+from typing import Optional
+
+from pynecone.components.component import Component
+from pynecone.components.layout import Box, Cond, Fragment
+from pynecone.components.typography import Text
+from pynecone.vars import Var
+
+
+class ConnectionBanner(Cond):
+    """A connection banner component."""
+
+    @classmethod
+    def create(cls, comp: Optional[Component] = None) -> Component:
+        """Create a connection banner component.
+
+        Args:
+            comp: The component to render when there's a server connection error.
+
+        Returns:
+            The connection banner component.
+        """
+        if not comp:
+            comp = Box.create(
+                Text.create(
+                    "cannot connect to server. Check if server is reachable",
+                    bg="red",
+                    color="white",
+                ),
+                textAlign="center",
+            )
+
+        return super().create(Var.create("notConnected"), comp, Fragment.create())  # type: ignore


### PR DESCRIPTION
This Pr adds a UI warning when server is unreachable
<img width="1512" alt="Screenshot 2023-05-31 at 3 34 45 PM" src="https://github.com/pynecone-io/pynecone/assets/19895635/6bf310bd-351d-4ceb-b08b-2473bfe457a2">

You also have the option of modifying the component that gets displayed.

```python

# Add state and page to the app.
app = pc.App(state=State, connect_error_component=pc.connection_banner(
    pc.box(
        pc.text(
            "cannot connect to server. This is edited",
            bg="black",
            color="white",
        ),
        textAlign="center",
    )
))
app.add_page(index)
app.compile()
```

To turn this feature/warning off, you can set the `check_connection` flag to False:

```python

# Add state and page to the app.
app = pc.App(state=State, check_connection=False)
app.add_page(index)
app.compile()
```
### All Submissions:

- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?


<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

closes #971 

