### PR TITLE
Fix processing flag for generator event handlers

### DIFF
--- a/pynecone/.templates/jinja/web/pages/index.js.jinja2
+++ b/pynecone/.templates/jinja/web/pages/index.js.jinja2
@@ -47,7 +47,7 @@ export default function Component() {
         {{const.result|react_setter}}({
           {{const.state}}: null,
           {{const.events}}: [],
-          {{const.processing}}: false,
+          {{const.processing}}: {{const.result}}.{{const.processing}},
         })
       }
 

--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -214,7 +214,7 @@ export const connect = async (
     update = JSON5.parse(update);
     applyDelta(state, update.delta);
     setResult({
-      processing: true,
+      processing: update.processing,
       state: state,
       events: update.events,
     });

--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -466,11 +466,11 @@ async def process(
     else:
         # Process the event.
         async for update in state._process(event):
-            yield update
+            # Postprocess the event.
+            update = await app.postprocess(state, event, update)
 
-        # Postprocess the event.
-        assert update is not None, "Process did not return an update."
-        update = await app.postprocess(state, event, update)
+            # Yield the update.
+            yield update
 
     # Set the state for the session.
     app.state_manager.set_state(event.token, state)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -673,12 +673,15 @@ async def test_process_event_generator(gen_state):
     count = 0
     async for update in gen:
         count += 1
-        assert gen_state.value == count
-        assert update.delta == {
-            "gen_state": {"value": count},
-        }
+        if count == 6:
+            assert update.delta == {}
+        else:
+            assert gen_state.value == count
+            assert update.delta == {
+                "gen_state": {"value": count},
+            }
 
-    assert count == 5
+    assert count == 6
 
 
 def test_format_event_handler():


### PR DESCRIPTION
Only set the processing flag to false after the last event has been generated.