### PR TITLE
[Fix 1169] Create empty directory for pc.get_asset_path() when .web init

### DIFF
--- a/pynecone/utils/prerequisites.py
+++ b/pynecone/utils/prerequisites.py
@@ -209,6 +209,7 @@ def initialize_web_directory():
     path_ops.rm(os.path.join(constants.WEB_TEMPLATE_DIR, constants.NODE_MODULES))
     path_ops.rm(os.path.join(constants.WEB_TEMPLATE_DIR, constants.PACKAGE_LOCK))
     path_ops.cp(constants.WEB_TEMPLATE_DIR, constants.WEB_DIR)
+    path_ops.mkdir(constants.WEB_ASSETS_DIR)
 
     # Write the current version of distributed pynecone package to a PCVERSION_APP_FILE."""
     with open(constants.PCVERSION_APP_FILE, "w") as f:


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

This PR is the Method 2 to solve the following issue.
- https://github.com/pynecone-io/pynecone/issues/1169
Make a empty folder `public` in `.web` in the `pc init` procedure. 