### PR TITLE
Fix pc.html using state vars

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -27,6 +27,7 @@ from pynecone.base import Base
 from pynecone.compiler import compiler
 from pynecone.compiler import utils as compiler_utils
 from pynecone.components.component import Component, ComponentStyle
+from pynecone.components.layout.fragment import Fragment
 from pynecone.config import get_config
 from pynecone.event import Event, EventHandler
 from pynecone.middleware import HydrateMiddleware, Middleware
@@ -288,6 +289,9 @@ class App(Base):
                     "See the var operation docs here: https://pynecone.io/docs/state/vars "
                 ) from e
             raise e
+
+        # Wrap the component in a fragment.
+        component = Fragment.create(component)
 
         # Add meta information to the component.
         compiler_utils.add_meta(

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -15,7 +15,7 @@ while ! nc -z localhost 3000 || ! lsof -i :8000 >/dev/null; do
       echo "Error: Server process with PID $pid exited early"
       break
   fi
-  if ((wait_time >= 500)); then
+  if ((wait_time >= 600)); then
     echo "Error: Timeout waiting for ports 3000 and 8000 to become available"
     exit 1
   fi


### PR DESCRIPTION
Wrap the entire page in a `pc.fragment` so that the meta-information is added into the fragment.

Test code:

```python
"""Welcome to Pynecone! This file create a counter app."""
import pynecone as pc


class State(pc.State):
    """The app state."""

    html: str = "<div>hello</div>"

def index() -> pc.Component:
    return pc.html(State.html)


# Add state and page to the app.
app = pc.App(state=State)
app.add_page(index, title="Counter")
app.compile()
```