### PR TITLE
fix: kill all descendant subprocesses of integration test script

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+kill_descendant_processes() {
+    local pid="$1"
+    local and_self="${2:-false}"
+    if children="$(pgrep -P "$pid")"; then
+        for child in $children; do
+            kill_descendant_processes "$child" true
+        done
+    fi
+    if [[ "$and_self" == true ]]; then
+        kill -9 "$pid"
+    fi
+}
+
 # Change directory to the first argument passed to the script
 cd "$1" || exit 1
 echo "Changed directory to $1"
@@ -27,7 +40,7 @@ done
 # Check if the server is still running
 if kill -0 "$pid" >/dev/null 2>&1; then
   echo "Integration test passed"
-  kill -TERM $(pgrep -P "$pid")
+  kill_descendant_processes $$
   exit 0
 else
   echo "Integration test failed"


### PR DESCRIPTION
bug: original version only kill direct subprcoess. After run integration test, the frontend process always survives so I use kill_descendant_processes to kill all descendant processes.

### All Submissions:

- [X] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [X] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [X] Does your submission pass the tests? 
- [X] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [X] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

fix: kill all descendant subprocesses of integration test script

    b. Describe your changes.

bug: original version only kill direct subprcoess.
    After run integration test, the frontend process always survives so I have to kill it manually.
    Now it will be killed automatically.
    
    The process tree like this:
    
<img width="1381" alt="image" src="https://github.com/pynecone-io/pynecone/assets/33004323/b7cb5fd9-feb4-48a6-bc5c-b7e886cd2127">


    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

