### PR TITLE
fix upload file not set state before return

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -610,6 +610,9 @@ def upload(app: App):
         )
         # TODO: refactor this to handle yields.
         update = await state._process(event).__anext__()
+
+        # Set the state for the session.
+        app.state_manager.set_state(event.token, state)
         return update
 
     return upload_file


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Fix issue with upload_file does not run set_state before return.  