### PR TITLE
Bugfix: Gitignore file empty newlines

### DIFF
--- a/pynecone/utils/prerequisites.py
+++ b/pynecone/utils/prerequisites.py
@@ -180,11 +180,10 @@ def initialize_gitignore():
     # Subtract current ignored files.
     if os.path.exists(constants.GITIGNORE_FILE):
         with open(constants.GITIGNORE_FILE, "r") as f:
-            files -= set(f.read().replace(" ", "").strip().splitlines())
-
-    # Add the new files to the .gitignore file.
-    with open(constants.GITIGNORE_FILE, "a") as f:
-        f.write(f"\n{path_ops.join(files)}")
+            files |= set([line.strip() for line in f.readlines()])
+    # Write file to the .gitignore file.
+    with open(constants.GITIGNORE_FILE, "w") as f:
+        f.write(f"{(path_ops.join(sorted(files))).lstrip()}")
 
 
 def initialize_app_directory(app_name: str, template: constants.Template):

--- a/pynecone/utils/prerequisites.py
+++ b/pynecone/utils/prerequisites.py
@@ -181,7 +181,7 @@ def initialize_gitignore():
     if os.path.exists(constants.GITIGNORE_FILE):
         with open(constants.GITIGNORE_FILE, "r") as f:
             files |= set([line.strip() for line in f.readlines()])
-    # Write file to the .gitignore file.
+    # Write files to the .gitignore file.
     with open(constants.GITIGNORE_FILE, "w") as f:
         f.write(f"{(path_ops.join(sorted(files))).lstrip()}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -502,9 +502,7 @@ def test_initialize_non_existent_gitignore(tmp_path, mocker, gitignore_exists):
         mocker: The mock object.
         gitignore_exists: Whether a gitignore file exists in the root dir.
     """
-    sep = os.sep
     expected = constants.DEFAULT_GITIGNORE.copy()
-
     mocker.patch("pynecone.constants.GITIGNORE_FILE", tmp_path / ".gitignore")
 
     gitignore_file = tmp_path / ".gitignore"
@@ -512,8 +510,7 @@ def test_initialize_non_existent_gitignore(tmp_path, mocker, gitignore_exists):
     if gitignore_exists:
         gitignore_file.touch()
         gitignore_file.write_text(
-            """
-        pynecone.db
+            """pynecone.db
         __pycache__/
         """
         )
@@ -521,7 +518,5 @@ def test_initialize_non_existent_gitignore(tmp_path, mocker, gitignore_exists):
     prerequisites.initialize_gitignore()
 
     assert gitignore_file.exists()
-    file_content = gitignore_file.open().read()
-    file_content.replace(f"{sep}{sep}", sep)
-
-    assert set(file_content.split()) == expected
+    file_content = [line.strip() for line in gitignore_file.open().readlines()]
+    assert set(file_content) - expected == set()


### PR DESCRIPTION
Fixed issue with gitignore file adding newlines on every `pc init`
