### PR TITLE
Allow view overrides when registering models with admin

### DIFF
--- a/reflex/admin.py
+++ b/reflex/admin.py
@@ -10,4 +10,5 @@ class AdminDash:
     """Data used to build the admin dashboard."""
 
     models: list = field(default_factory=list)
+    view_overrides: dict = field(default_factory=dict)
     admin: Optional[Admin] = None

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -428,8 +428,11 @@ class App(Base):
                     logo_url="https://pynecone.io/logo.png",
                 )
             )
+
             for model in config.admin_dash.models:
-                admin.add_view(ModelView(model))
+                view = config.admin_dash.view_overrides.get(model, ModelView)
+                admin.add_view(view(model))
+
             admin.mount_to(self.api)
 
     def compile(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,6 +13,7 @@ import sqlmodel
 from fastapi import UploadFile
 from starlette_admin.auth import AuthProvider
 from starlette_admin.contrib.sqla.admin import Admin
+from starlette_admin.contrib.sqla.view import ModelView
 
 from reflex import AdminDash, constants
 from reflex.app import App, DefaultState, process, upload
@@ -264,6 +265,26 @@ def test_initialize_with_custom_admin_dashboard(
     assert len(app.admin_dash.models) > 0
     assert app.admin_dash.models[0] == test_model_auth
     assert app.admin_dash.admin.auth_provider == test_custom_auth_admin
+
+
+def test_initialize_admin_dashboard_with_view_overrides(test_model):
+    """Test setting the admin dashboard of an app with view class overriden.
+
+    Args:
+        test_model: The default model.
+    """
+
+    class TestModelView(ModelView):
+        pass
+
+    app = App(
+        admin_dash=AdminDash(
+            models=[test_model], view_overrides={test_model: TestModelView}
+        )
+    )
+    assert app.admin_dash is not None
+    assert app.admin_dash.models == [test_model]
+    assert app.admin_dash.view_overrides[test_model] == TestModelView
 
 
 def test_initialize_with_state(test_state):


### PR DESCRIPTION
Closes #1224 

- Add `view_overrides` dictionary to `reflex.admin.AdminDash` to store custom view classes for models when registering them with the admin dashboard.
- This lets us configure admin pages for each model separately.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls) for the desired changed?

### Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

