### PR TITLE
state: Leading underscore functions are not backend vars

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -10,6 +10,7 @@ import traceback
 import urllib.parse
 from abc import ABC
 from collections import defaultdict
+from types import FunctionType
 from typing import (
     Any,
     AsyncIterator,
@@ -197,6 +198,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             for name, value in cls.__dict__.items()
             if types.is_backend_variable(name)
             and name not in cls.inherited_backend_vars
+            and not isinstance(value, FunctionType)
         }
 
         cls.backend_vars = {**cls.inherited_backend_vars, **cls.new_backend_vars}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1087,3 +1087,18 @@ def test_computed_var_depends_on_parent_non_cached():
         IS_HYDRATED: False,
     }
     assert counter == 6
+
+
+def test_backend_method():
+    """A method with leading underscore should be callable from event handler."""
+
+    class BackendMethodState(State):
+        def _be_method(self):
+            return True
+
+        def handler(self):
+            assert self._be_method()
+
+    bms = BackendMethodState()
+    bms.handler()
+    assert bms._be_method()


### PR DESCRIPTION
When initializing backend variables in `__init_subclass__`, exclude functions, so they can eventually become bound methods on state instances. (Otherwise, they are treated like backend variables, and that takes precedence in `__getattribute__`.)

# Bug fix

This fix potentially breaks code that is using a workaround for the previous behavior and just passing `self`... i think some of the examples do this; will have to double check.

Fixes https://github.com/pynecone-io/pynecone/issues/1267