### PR TITLE
Fix missing stdout in event handlers

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -133,7 +133,7 @@ def run_backend(
         "--reload-exclude",
         f"'{constants.WEB_DIR}/*'",
     ]
-    process = new_process(cmd)
+    process = subprocess.Popen(cmd)
 
     try:
         process.wait()


### PR DESCRIPTION
We shouldn't redirect stdout for the backend process.