### PR TITLE
reflex export: `get_app` before `setup_frontend`

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -228,8 +228,10 @@ def export(
     console.rule("[bold]Compiling production app and preparing for export.")
 
     if frontend:
-        build.setup_frontend(Path.cwd())
+        # ensure module can be imported and app.compile() is called
         prerequisites.get_app()
+        # set up .web directory and install frontend dependencies
+        build.setup_frontend(Path.cwd())
 
     build.export_app(
         backend=backend,


### PR DESCRIPTION
Import the app module first, since it may programmatically modify the rxconfig, which can influence how setup_frontend works.

For example, if the app module adds entries to `frontend_packages`, this must occur before setup_frontend installs frontend packages.

This ordering matches how `run` is currently implemented.