### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1836,4 +1836,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "c7ef30a96b3882cdd07982ce661e174edd8ae8cd52976a23e02f16a6b8cd3eae"
+content-hash = "b07623f193778651dd3ece81370d2d9a2ba3b53855a57baf0147e67bf07aaed8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ watchfiles = "^0.19.0"
 websockets = "^10.4"
 starlette-admin = "^0.9.0"
 python-dotenv = "^0.13.0"
+importlib-metadata = {version = "^6.7.0", python = ">=3.7, <3.8"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -6,7 +6,11 @@ from enum import Enum
 from types import SimpleNamespace
 from typing import Any, Type
 
-import pkg_resources
+# importlib is only available for Python 3.8+ so we need the backport for Python 3.7
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
 
 
 def get_value(key: str, default: Any = None, type_: Type = str) -> Type:
@@ -38,7 +42,7 @@ def get_value(key: str, default: Any = None, type_: Type = str) -> Type:
 # The name of the Reflex package.
 MODULE_NAME = "reflex"
 # The current version of Reflex.
-VERSION = pkg_resources.get_distribution(MODULE_NAME).version
+VERSION = metadata.version(MODULE_NAME)
 # Minimum version of Node.js required to run Reflex.
 MIN_NODE_VERSION = "16.8.0"
 


### PR DESCRIPTION
### All Submissions:

Closes #1300 

- Replace `pkg_resources.get_distribution(MODULE_NAME).version` with `importlib.metadata.version(MODULE_NAME)`
- As `importlib` was only introduced in Python 3.8, this required adding `importlib_metadata` backport as a dependency in case we're running Python 3.7.

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

