### PR TITLE
component: do not create ref for dynamic id

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -553,7 +553,8 @@ class Component(Base, ABC):
         Returns:
             The ref name.
         """
-        if self.id is None:
+        # do not create a ref if the id is dynamic or unspecified
+        if self.id is None or isinstance(self.id, BaseVar):
             return None
         return format.format_ref(self.id)
 


### PR DESCRIPTION
allow dynamic id (BaseVar) to be specified (from state value or foreach), but do not create a react reference for it, since that must be known at compile time.

if a react ref is needed, then specify a string _at compile time_, not from state.

fix #1302