### PR TITLE
Computed vars tuple and str indexing support

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Set,
     Type,
+    Tuple,
     Union,
     _GenericAlias,  # type: ignore
     cast,
@@ -200,7 +201,7 @@ class Var(ABC):
         """
         # Indexing is only supported for lists, dicts, and dataframes.
         if not (
-            types._issubclass(self.type_, Union[List, Dict])
+            types._issubclass(self.type_, Union[List, Dict, Tuple])
             or types.is_dataframe(self.type_)
         ):
             if self.type_ == Any:
@@ -219,7 +220,7 @@ class Var(ABC):
             i = BaseVar(name=i.name, type_=i.type_, state=i.state, is_local=True)
 
         # Handle list indexing.
-        if types._issubclass(self.type_, List):
+        if types._issubclass(self.type_, Union[List, Tuple]):
             # List indices must be ints, slices, or vars.
             if not isinstance(i, types.get_args(Union[int, slice, Var])):
                 raise TypeError("Index must be an integer.")

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -199,9 +199,9 @@ class Var(ABC):
         Raises:
             TypeError: If the var is not indexable.
         """
-        # Indexing is only supported for lists, tuples, dicts, and dataframes.
+        # Indexing is only supported for strings, lists, tuples, dicts, and dataframes.
         if not (
-            types._issubclass(self.type_, Union[List, Dict, Tuple])
+            types._issubclass(self.type_, Union[List, Dict, Tuple, str])
             or types.is_dataframe(self.type_)
         ):
             if self.type_ == Any:
@@ -219,9 +219,9 @@ class Var(ABC):
         if isinstance(i, Var):
             i = BaseVar(name=i.name, type_=i.type_, state=i.state, is_local=True)
 
-        # Handle list/tuple indexing.
-        if types._issubclass(self.type_, Union[List, Tuple]):
-            # List/Tuple indices must be ints, slices, or vars.
+        # Handle list/tuple/str indexing.
+        if types._issubclass(self.type_, Union[List, Tuple, str]):
+            # List/Tuple/String indices must be ints, slices, or vars.
             if not isinstance(i, types.get_args(Union[int, slice, Var])):
                 raise TypeError("Index must be an integer.")
 

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -16,8 +16,8 @@ from typing import (
     List,
     Optional,
     Set,
-    Type,
     Tuple,
+    Type,
     Union,
     _GenericAlias,  # type: ignore
     cast,

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -199,7 +199,7 @@ class Var(ABC):
         Raises:
             TypeError: If the var is not indexable.
         """
-        # Indexing is only supported for lists, dicts, and dataframes.
+        # Indexing is only supported for lists, tuples, dicts, and dataframes.
         if not (
             types._issubclass(self.type_, Union[List, Dict, Tuple])
             or types.is_dataframe(self.type_)
@@ -219,9 +219,9 @@ class Var(ABC):
         if isinstance(i, Var):
             i = BaseVar(name=i.name, type_=i.type_, state=i.state, is_local=True)
 
-        # Handle list indexing.
+        # Handle list/tuple indexing.
         if types._issubclass(self.type_, Union[List, Tuple]):
-            # List indices must be ints, slices, or vars.
+            # List/Tuple indices must be ints, slices, or vars.
             if not isinstance(i, types.get_args(Union[int, slice, Var])):
                 raise TypeError("Index must be an integer.")
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import cloudpickle
 import pytest
@@ -272,31 +272,41 @@ def test_basic_operations(TestObj):
     assert str(v([1, 2, 3]).length()) == "{[1, 2, 3].length}"
 
 
-def test_var_indexing_lists():
-    """Test that we can index into list vars."""
-    lst = BaseVar(name="lst", type_=List[int])
-
+@pytest.mark.parametrize(
+    "var",
+    [
+        BaseVar(name="lst", type_=List[int]),
+        BaseVar(name="tuple", type_=Tuple[int, int]),
+    ],
+)
+def test_var_indexing_lists(var):
+    """Test that we can index into list or tuple vars."""
     # Test basic indexing.
-    assert str(lst[0]) == "{lst.at(0)}"
-    assert str(lst[1]) == "{lst.at(1)}"
+    assert str(var[0]) == f"{{{var.name}.at(0)}}"
+    assert str(var[1]) == f"{{{var.name}.at(1)}}"
 
     # Test negative indexing.
-    assert str(lst[-1]) == "{lst.at(-1)}"
+    assert str(var[-1]) == f"{{{var.name}.at(-1)}}"
 
     # Test non-integer indexing raises an error.
     with pytest.raises(TypeError):
-        lst["a"]
+        var["a"]
     with pytest.raises(TypeError):
-        lst[1.5]
+        var[1.5]
 
 
-def test_var_list_slicing():
-    """Test that we can slice into list vars."""
-    lst = BaseVar(name="lst", type_=List[int])
-
-    assert str(lst[:1]) == "{lst.slice(0, 1)}"
-    assert str(lst[:1]) == "{lst.slice(0, 1)}"
-    assert str(lst[:]) == "{lst.slice(0, undefined)}"
+@pytest.mark.parametrize(
+    "var",
+    [
+        BaseVar(name="lst", type_=List[int]),
+        BaseVar(name="tuple", type_=Tuple[int, int]),
+    ],
+)
+def test_var_list_slicing(var):
+    """Test that we can slice into list or tuple vars."""
+    assert str(var[:1]) == f"{{{var.name}.slice(0, 1)}}"
+    assert str(var[:1]) == f"{{{var.name}.slice(0, 1)}}"
+    assert str(var[:]) == f"{{{var.name}.slice(0, undefined)}}"
 
 
 def test_dict_indexing():

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -275,15 +275,16 @@ def test_basic_operations(TestObj):
 @pytest.mark.parametrize(
     "var",
     [
-        BaseVar(name="lst", type_=List[int]),
+        BaseVar(name="list", type_=List[int]),
         BaseVar(name="tuple", type_=Tuple[int, int]),
+        BaseVar(name="str", type_=str),
     ],
 )
 def test_var_indexing_lists(var):
-    """Test that we can index into list or tuple vars.
+    """Test that we can index into str, list or tuple vars.
 
     Args:
-        var : The list or tuple base var.
+        var : The str, list or tuple base var.
     """
     # Test basic indexing.
     assert str(var[0]) == f"{{{var.name}.at(0)}}"
@@ -304,13 +305,14 @@ def test_var_indexing_lists(var):
     [
         BaseVar(name="lst", type_=List[int]),
         BaseVar(name="tuple", type_=Tuple[int, int]),
+        BaseVar(name="str", type_=str),
     ],
 )
 def test_var_list_slicing(var):
-    """Test that we can slice into list or tuple vars.
+    """Test that we can slice into str, list or tuple vars.
 
     Args:
-        var : The list or tuple base var.
+        var : The str, list or tuple base var.
     """
     assert str(var[:1]) == f"{{{var.name}.slice(0, 1)}}"
     assert str(var[:1]) == f"{{{var.name}.slice(0, 1)}}"

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -280,7 +280,11 @@ def test_basic_operations(TestObj):
     ],
 )
 def test_var_indexing_lists(var):
-    """Test that we can index into list or tuple vars."""
+    """Test that we can index into list or tuple vars.
+
+    Args:
+        var : The list or tuple base var.
+    """
     # Test basic indexing.
     assert str(var[0]) == f"{{{var.name}.at(0)}}"
     assert str(var[1]) == f"{{{var.name}.at(1)}}"
@@ -303,7 +307,11 @@ def test_var_indexing_lists(var):
     ],
 )
 def test_var_list_slicing(var):
-    """Test that we can slice into list or tuple vars."""
+    """Test that we can slice into list or tuple vars.
+
+    Args:
+        var : The list or tuple base var.
+    """
     assert str(var[:1]) == f"{{{var.name}.slice(0, 1)}}"
     assert str(var[:1]) == f"{{{var.name}.slice(0, 1)}}"
     assert str(var[:]) == f"{{{var.name}.slice(0, undefined)}}"


### PR DESCRIPTION
added support for tuples. This should work now:

```python
...
    @rx.var
    def elements(self) -> Tuple[str, str]:
        return "hello", "world"
...

```
indexing str vars should also work:

```python

class State(rx.State):
      value: str = "hello world"
   
def index():
     return rx.vstack(
     rx.text(State.value[0]),
     rx.text(State.value[3:-1])
)

```

fixes #1325

