### PR TITLE
Add debounce_input based on react-debounce-input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v1.1.313
     hooks:
     - id: pyright
-      args: [reflex, tests]
+      args: [integration, reflex, tests]
       language: system
 
   - repo: https://github.com/terrencepreilly/darglint
@@ -21,4 +21,4 @@ repos:
     rev: 22.10.0
     hooks:
     - id: black
-      args: [reflex, tests]
+      args: [integration, reflex, tests]

--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -1,0 +1,91 @@
+"""Integration tests for text input and related components."""
+import time
+from typing import Generator
+
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+from reflex.testing import AppHarness
+
+
+def FullyControlledInput():
+    """App using a fully controlled input with debounce wrapper."""
+    import reflex as rx
+
+    class State(rx.State):
+        text: str = "initial"
+
+    app = rx.App(state=State)
+
+    @app.add_page
+    def index():
+        return rx.debounce_input(
+            rx.input(
+                value=State.text,
+                on_change=State.set_text,  # type: ignore
+            ),
+            debounce_timeout=0,
+        )
+
+    app.compile()
+
+
+@pytest.fixture()
+def fully_controlled_input(tmp_path) -> Generator[AppHarness, None, None]:
+    """Start FullyControlledInput app at tmp_path via AppHarness.
+
+    Args:
+        tmp_path: pytest tmp_path fixture
+
+    Yields:
+        running AppHarness instance
+    """
+    with AppHarness.create(
+        root=tmp_path,
+        app_source=FullyControlledInput,  # type: ignore
+    ) as harness:
+        yield harness
+
+
+@pytest.mark.asyncio
+async def test_fully_controlled_input(fully_controlled_input: AppHarness):
+    """Type text after moving cursor. Update text on backend.
+
+    Args:
+        fully_controlled_input: harness for FullyControlledInput app
+    """
+    assert fully_controlled_input.app_instance is not None, "app is not running"
+    driver = fully_controlled_input.frontend()
+
+    # get a reference to the connected client
+    assert len(fully_controlled_input.poll_for_clients()) == 1
+    token, backend_state = list(
+        fully_controlled_input.app_instance.state_manager.states.items()
+    )[0]
+
+    # find the input and wait for it to have the initial state value
+    text_input = driver.find_element(By.TAG_NAME, "input")
+    assert fully_controlled_input.poll_for_value(text_input) == "initial"
+
+    # move cursor to home, then to the right and type characters
+    text_input.send_keys(Keys.HOME, Keys.ARROW_RIGHT)
+    text_input.send_keys("foo")
+    assert text_input.get_attribute("value") == "ifoonitial"
+    assert backend_state.text == "ifoonitial"
+
+    # clear the input on the backend
+    backend_state.text = ""
+    fully_controlled_input.app_instance.state_manager.set_state(token, backend_state)
+    await fully_controlled_input.emit_state_updates()
+    assert backend_state.text == ""
+    assert (
+        fully_controlled_input.poll_for_value(text_input, exp_not_equal="ifoonitial")
+        == ""
+    )
+
+    # type more characters
+    text_input.send_keys("getting testing done")
+    time.sleep(0.1)
+    assert text_input.get_attribute("value") == "getting testing done"
+    assert backend_state.text == "getting testing done"

--- a/reflex/.templates/web/package.json
+++ b/reflex/.templates/web/package.json
@@ -22,6 +22,7 @@
     "next": "^13.3.1",
     "plotly.js": "^2.22.0",
     "react": "^18.2.0",
+    "react-debounce-input": "^3.3.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-markdown": "^8.0.7",

--- a/reflex/components/__init__.py
+++ b/reflex/components/__init__.py
@@ -94,6 +94,7 @@ checkbox_group = CheckboxGroup.create
 copy_to_clipboard = CopyToClipboard.create
 date_picker = DatePicker.create
 date_time_picker = DateTimePicker.create
+debounce_input = DebounceInput.create
 editable = Editable.create
 editable_input = EditableInput.create
 editable_preview = EditablePreview.create

--- a/reflex/components/forms/__init__.py
+++ b/reflex/components/forms/__init__.py
@@ -11,6 +11,7 @@ from .colormodeswitch import (
 from .copytoclipboard import CopyToClipboard
 from .date_picker import DatePicker
 from .date_time_picker import DateTimePicker
+from .debounce import DebounceInput
 from .editable import Editable, EditableInput, EditablePreview, EditableTextarea
 from .email import Email
 from .form import Form, FormControl, FormErrorMessage, FormHelperText, FormLabel

--- a/reflex/components/forms/debounce.py
+++ b/reflex/components/forms/debounce.py
@@ -1,0 +1,77 @@
+"""Wrapper around react-debounce-input."""
+from __future__ import annotations
+
+from typing import Any
+
+from reflex.components import Component
+from reflex.components.tags import Tag
+from reflex.vars import Var
+
+
+class DebounceInput(Component):
+    """The DebounceInput component is used to buffer input events on the client side.
+
+    It is intended to wrap various form controls and should be used whenever a
+    fully-controlled input is needed to prevent lost input data when the backend
+    is experiencing high latency.
+    """
+
+    library = "react-debounce-input"
+    tag = "DebounceInput"
+
+    # Minimum input characters before triggering the on_change event
+    min_length: Var[int] = 0  # type: ignore
+
+    # Time to wait between end of input and triggering on_change
+    debounce_timeout: Var[int] = 100  # type: ignore
+
+    # If true, notify when Enter key is pressed
+    force_notify_by_enter: Var[bool] = True  # type: ignore
+
+    # If true, notify when form control loses focus
+    force_notify_on_blur: Var[bool] = True  # type: ignore
+
+    def _render(self) -> Tag:
+        """Carry first child props directly on this tag.
+
+        Since react-debounce-input wants to create and manage the underlying
+        input component itself, we carry all props, events, and styles from
+        the child, and then neuter the child's render method so it produces no output.
+
+        Returns:
+            The rendered debounce element wrapping the first child element.
+
+        Raises:
+            RuntimeError: unless exactly one child element is provided.
+        """
+        if not self.children or len(self.children) > 1:
+            raise RuntimeError(
+                "Provide a single child for DebounceInput, such as rx.input() or "
+                "rx.text_area()",
+            )
+        child = self.children[0]
+        tag = super()._render()
+        tag.add_props(
+            **child.event_triggers,
+            **props_not_none(child),
+            sx=child.style,
+            id=child.id,
+            class_name=child.class_name,
+            element=Var.create("{%s}" % child.tag, is_local=False, is_string=False),
+        )
+        # do NOT render the child, DebounceInput will create it
+        object.__setattr__(child, "render", lambda: "")
+        return tag
+
+
+def props_not_none(c: Component) -> dict[str, Any]:
+    """Get all properties of the component that are not None.
+
+    Args:
+        c: the component to get_props from
+
+    Returns:
+        dict of all props that are not None.
+    """
+    cdict = {a: getattr(c, a) for a in c.get_props() if getattr(c, a, None) is not None}
+    return cdict


### PR DESCRIPTION
The debounce_input component can help reduce roundtrips when using fully controlled input elements. This is especially critical in situations of high latency and also fixes the issue where the cursor moves to the end of the input while typing.

Addresses #673 and #1087

Originally available as https://github.com/trivial-intelligence/reflex-debounce-input